### PR TITLE
Disallow stdlib functions that print to stdio

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -4,7 +4,7 @@ set -e
 # Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github "
-DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(')
+DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(' 'fmt.Println(' 'fmt.Printf(' 'log.Print(' 'log.Println(' 'log.Printf(')
 
 
 for disallowedFunction in "${DISALLOWED_FUNCTIONS[@]}"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pion/srtp
 go 1.12
 
 require (
+	github.com/pion/logging v0.2.1
 	github.com/pion/rtcp v1.1.4
 	github.com/pion/rtp v1.1.1
 	github.com/pion/transport v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pion/logging v0.2.1 h1:LwASkBKZ+2ysGJ+jLv1E/9H1ge0k1nTfi1X+5zirkDk=
+github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/rtcp v1.1.4 h1:LW1zS49QXeuhKyFr7hFOlvnZZ2cR8lluTYg5jilGnKY=
 github.com/pion/rtcp v1.1.4/go.mod h1:a5dj2d6BKIKHl43EnAOIrCczcjESrtPuMgfmL6/K6QM=
 github.com/pion/rtp v1.1.1 h1:lag+9/lSOLBEYeYB/28KXm/ka1H++4wkmSj/WkttV6Y=

--- a/session_srtcp.go
+++ b/session_srtcp.go
@@ -2,10 +2,12 @@ package srtp
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 
+	"github.com/pion/logging"
 	"github.com/pion/rtcp"
 )
 
@@ -20,6 +22,15 @@ type SessionSRTCP struct {
 
 // NewSessionSRTCP creates a SRTCP session using conn as the underlying transport.
 func NewSessionSRTCP(conn net.Conn, config *Config) (*SessionSRTCP, error) {
+	if config == nil {
+		return nil, errors.New("no config provided")
+	}
+
+	loggerFactory := config.LoggerFactory
+	if loggerFactory == nil {
+		loggerFactory = logging.NewDefaultLoggerFactory()
+	}
+
 	s := &SessionSRTCP{
 		session: session{
 			nextConn:    conn,
@@ -27,6 +38,7 @@ func NewSessionSRTCP(conn net.Conn, config *Config) (*SessionSRTCP, error) {
 			newStream:   make(chan readStream),
 			started:     make(chan interface{}),
 			closed:      make(chan interface{}),
+			log:         loggerFactory.NewLogger("srtp"),
 		},
 	}
 	s.writeStream = &WriteStreamSRTCP{s}

--- a/session_srtp.go
+++ b/session_srtp.go
@@ -1,9 +1,11 @@
 package srtp
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
+	"github.com/pion/logging"
 	"github.com/pion/rtp"
 )
 
@@ -18,6 +20,15 @@ type SessionSRTP struct {
 
 // NewSessionSRTP creates a SRTP session using conn as the underlying transport.
 func NewSessionSRTP(conn net.Conn, config *Config) (*SessionSRTP, error) {
+	if config == nil {
+		return nil, errors.New("no config provided")
+	}
+
+	loggerFactory := config.LoggerFactory
+	if loggerFactory == nil {
+		loggerFactory = logging.NewDefaultLoggerFactory()
+	}
+
 	s := &SessionSRTP{
 		session: session{
 			nextConn:    conn,
@@ -25,6 +36,7 @@ func NewSessionSRTP(conn net.Conn, config *Config) (*SessionSRTP, error) {
 			newStream:   make(chan readStream),
 			started:     make(chan interface{}),
 			closed:      make(chan interface{}),
+			log:         loggerFactory.NewLogger("srtp"),
 		},
 	}
 	s.writeStream = &WriteStreamSRTP{s}


### PR DESCRIPTION
All printing to stdio must be done via pion/logging,
all calls to common printing functions will not cause CI
to fail

Relates to pion/webrtc#361
