### PR TITLE
Create destinationSSRC without initial values

### DIFF
--- a/session_srtcp.go
+++ b/session_srtcp.go
@@ -116,8 +116,7 @@ func destinationSSRC(pkts []rtcp.Packet) []uint32 {
 		}
 	}
 
-	out := make([]uint32, len(ssrcSet))
-
+	out := make([]uint32, 0, len(ssrcSet))
 	for ssrc := range ssrcSet {
 		out = append(out, ssrc)
 	}


### PR DESCRIPTION
destinationSSRC was allocating a slice of length n,
which was being filled with zero values. Instead allocate
slice with capacity, but no values.