### PR TITLE
Upgrade golangci-lint to 1.19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
   email: false
 
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.18.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.19.1
 
 script:
   - golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Max Hawkins](https://github.com/maxhawkins)
 * [Woodrow Douglass](https://github.com/wdouglass)
 * [Hugo Arregui](https://github.com/hugoArregui)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/context.go
+++ b/context.go
@@ -265,7 +265,6 @@ func (c *Context) updateRolloverCount(sequenceNumber uint16, s *ssrcState) {
 	if !s.rolloverHasProcessed {
 		s.rolloverHasProcessed = true
 	} else if sequenceNumber == 0 { // We exactly hit the rollover count
-
 		// Only update rolloverCounter if lastSequenceNumber is greater then maxROCDisorder
 		// otherwise we already incremented for disorder
 		if s.lastSequenceNumber > maxROCDisorder {

--- a/keying.go
+++ b/keying.go
@@ -41,5 +41,4 @@ func (c *Config) ExtractSessionKeysFromDTLS(exporter KeyingMaterialExporter, isC
 	c.Keys.RemoteMasterKey = clientWriteKey[0:keyLen]
 	c.Keys.RemoteMasterSalt = clientWriteKey[keyLen:]
 	return nil
-
 }

--- a/keying_test.go
+++ b/keying_test.go
@@ -65,6 +65,5 @@ func TestExtractSessionKeysFromDTLS(t *testing.T) {
 		if !bytes.Equal(serverMaterial, m.exported) {
 			t.Errorf("material reconstruction failed for %d-server:\n%#v\nexpected\n%#v", i, serverMaterial, m.exported)
 		}
-
 	}
 }

--- a/srtp.go
+++ b/srtp.go
@@ -1,3 +1,4 @@
+// Package srtp implements Secure Real-time Transport Protocol
 package srtp
 
 import (

--- a/srtp_test.go
+++ b/srtp_test.go
@@ -46,7 +46,6 @@ func TestValidSessionKeys(t *testing.T) {
 	sessionKey, err := c.generateSessionKey(labelSRTPEncryption)
 	if err != nil {
 		t.Errorf("generateSessionKey failed: %v", err)
-
 	} else if !bytes.Equal(sessionKey, expectedSessionKey) {
 		t.Errorf("Session Key % 02x does not match expected % 02x", sessionKey, expectedSessionKey)
 	}
@@ -64,7 +63,6 @@ func TestValidSessionKeys(t *testing.T) {
 	} else if !bytes.Equal(sessionAuthTag, expectedSessionAuthTag) {
 		t.Errorf("Session Auth Tag % 02x does not match expected % 02x", sessionAuthTag, expectedSessionAuthTag)
 	}
-
 }
 
 func TestValidPacketCounter(t *testing.T) {

--- a/stream_srtp.go
+++ b/stream_srtp.go
@@ -107,7 +107,6 @@ func (r *ReadStreamSRTP) Close() error {
 		r.session.removeReadStream(r.ssrc)
 		return nil
 	}
-
 }
 
 // GetSSRC returns the SSRC we are demuxing for


### PR DESCRIPTION
Fix whitespace and stylecheck error.

preparing pion/.goassets#4