### PR TITLE
Spamming info message into log

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Woodrow Douglass](https://github.com/wdouglass)
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Atsushi Watanabe](https://github.com/at-wat)
+* [Novel Corpse](https://github.com/NovelCorpse)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
#### Description
Hello, everyone! I've got same #22 problem with spamming info messages regarding full buffer into logs. 

I'm not sure, but may be we can fix it like for [stream_srtp](https://github.com/pion/srtp/blob/master/stream_srtp.go#L59) ?
Also I've removed unusable [condition](https://github.com/pion/srtp/blob/master/stream_srtcp.go#L56), because packetio.Buffer's Read() never returns ErrFull.


I would appreciate for your reply.
Best regard, Roman.

