### PR TITLE
Reduce lock contention in (*SessionSRTP).writeRTP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Novel Corpse](https://github.com/NovelCorpse)
 * [Jerko Steiner](https://github.com/jeremija)
+* [Juliusz Chroboczek](https://github.com/jech)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/session_srtp.go
+++ b/session_srtp.go
@@ -125,9 +125,8 @@ func (s *SessionSRTP) writeRTP(header *rtp.Header, payload []byte) (int, error) 
 	}
 
 	s.session.localContextMutex.Lock()
-	defer s.session.localContextMutex.Unlock()
-
 	encrypted, err := s.localContext.encryptRTP(nil, header, payload)
+	s.session.localContextMutex.Unlock()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This avoids performing I/O under a lock.  On a 4-core CPU, this has been measured as reducing roughly by half the total amount of lock contention in the Unnamed SFU, not counting contention due to the operations queue.

The remaining lock contention is almost entirely at line 129 just above, but that's for later.