### PR TITLE
Optimise away calls to cipher.NewCTR

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -1,0 +1,58 @@
+package srtp
+
+import (
+	"crypto/cipher"
+)
+
+// xorBytes computes the exclusive-or of src1 and src2 and stores it in dst.
+// It returns the number of bytes written.
+func xorBytes(dst, src1, src2 []byte) int {
+	n := len(src1)
+	if len(src2) < n {
+		n = len(src2)
+	}
+	if len(dst) < n {
+		n = len(dst)
+	}
+
+	for i := 0; i < n; i++ {
+		dst[i] = src1[i] ^ src2[i]
+	}
+
+	return n
+}
+
+// incrementCTR increments a big-endian integer of arbitrary size.
+func incrementCTR(ctr []byte) {
+	for i := len(ctr) - 1; i >= 0; i-- {
+		ctr[i]++
+		if ctr[i] != 0 {
+			break
+		}
+	}
+}
+
+// xorBytesCTR performs CTR encryption and decryption.
+// It is equivalent to cipher.NewCTR followed by XORKeyStream.
+func xorBytesCTR(block cipher.Block, iv []byte, dst, src []byte) error {
+	if len(iv) != block.BlockSize() {
+		return errBadIVLength
+	}
+
+	ctr := make([]byte, len(iv))
+	copy(ctr, iv)
+	bs := block.BlockSize()
+	stream := make([]byte, bs)
+
+	i := 0
+	for i < len(src) {
+		block.Encrypt(stream, ctr)
+		incrementCTR(ctr)
+		n := xorBytes(dst[i:], src[i:], stream)
+		if n == 0 {
+			break
+		}
+		i += n
+	}
+	return nil
+}

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -1,0 +1,159 @@
+package srtp
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func xorBytesCTRReference(block cipher.Block, iv []byte, dst, src []byte) {
+	stream := cipher.NewCTR(block, iv)
+	stream.XORKeyStream(dst, src)
+}
+
+func TestXorBytesCTR(t *testing.T) {
+	for keysize := 16; keysize < 64; keysize *= 2 {
+		key := make([]byte, keysize)
+		_, err := rand.Read(key) //nolint: gosec
+		require.NoError(t, err)
+
+		block, err := aes.NewCipher(key)
+		require.NoError(t, err)
+
+		iv := make([]byte, block.BlockSize())
+		for i := 0; i < 1500; i++ {
+			src := make([]byte, i)
+			dst := make([]byte, i)
+			reference := make([]byte, i)
+			_, err = rand.Read(iv) //nolint: gosec
+			require.NoError(t, err)
+
+			_, err = rand.Read(src) //nolint: gosec
+			require.NoError(t, err)
+
+			assert.NoError(t, xorBytesCTR(block, iv, dst, src))
+			xorBytesCTRReference(block, iv, reference, src)
+			require.Equal(t, dst, reference)
+
+			// test overlap
+			assert.NoError(t, xorBytesCTR(block, iv, dst, dst))
+			xorBytesCTRReference(block, iv, reference, reference)
+			require.Equal(t, dst, reference)
+		}
+	}
+}
+
+func TestXorBytesCTRInvalidIvLength(t *testing.T) {
+	key := make([]byte, 16)
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+
+	src := make([]byte, 1024)
+	dst := make([]byte, 1024)
+
+	test := func(iv []byte) {
+		assert.Error(t, errBadIVLength, xorBytesCTR(block, iv, dst, src))
+	}
+
+	test(make([]byte, block.BlockSize()-1))
+	test(make([]byte, block.BlockSize()+1))
+}
+
+func TestXorBytesBufferSize(t *testing.T) {
+	a := []byte{3}
+	b := []byte{5, 6}
+	dst := make([]byte, 3)
+
+	xorBytes(dst, a, b)
+	require.Equal(t, dst, []byte{6, 0, 0})
+
+	xorBytes(dst, b, a)
+	require.Equal(t, dst, []byte{6, 0, 0})
+
+	a = []byte{1, 1, 1, 1}
+	b = []byte{2, 2, 2, 2}
+	dst = make([]byte, 3)
+
+	xorBytes(dst, a, b)
+	require.Equal(t, dst, []byte{3, 3, 3})
+}
+
+func benchmarkXorBytesCTR(b *testing.B, size int) {
+	key := make([]byte, 16)
+	_, err := rand.Read(key) //nolint: gosec
+	require.NoError(b, err)
+
+	block, err := aes.NewCipher(key)
+	require.NoError(b, err)
+
+	iv := make([]byte, 16)
+	src := make([]byte, 1024)
+	dst := make([]byte, 1024)
+
+	b.SetBytes(int64(size))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := rand.Read(iv) //nolint: gosec
+		require.NoError(b, err)
+
+		_, err = rand.Read(src) //nolint: gosec
+		require.NoError(b, err)
+
+		assert.NoError(b, xorBytesCTR(block, iv, dst, src))
+	}
+}
+
+func BenchmarkXorBytesCTR14(b *testing.B) {
+	benchmarkXorBytesCTR(b, 14)
+}
+
+func BenchmarkXorBytesCTR140(b *testing.B) {
+	benchmarkXorBytesCTR(b, 140)
+}
+
+func BenchmarkXorBytesCTR1400(b *testing.B) {
+	benchmarkXorBytesCTR(b, 1400)
+}
+
+func benchmarkXorBytesCTRReference(b *testing.B, size int) {
+	key := make([]byte, 16)
+	_, err := rand.Read(key) //nolint: gosec
+	if err != nil {
+		b.Fatalf("rand.Read: %v", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		b.Fatalf("NewCipher: %v", err)
+	}
+	iv := make([]byte, 16)
+	src := make([]byte, 1024)
+	dst := make([]byte, 1024)
+
+	b.SetBytes(int64(size))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := rand.Read(iv) //nolint: gosec
+		require.NoError(b, err)
+
+		_, err = rand.Read(src) //nolint: gosec
+		require.NoError(b, err)
+
+		xorBytesCTRReference(block, iv, dst, src)
+	}
+}
+
+func BenchmarkXorBytesCTR14Reference(b *testing.B) {
+	benchmarkXorBytesCTRReference(b, 14)
+}
+
+func BenchmarkXorBytesCTR140Reference(b *testing.B) {
+	benchmarkXorBytesCTRReference(b, 140)
+}
+
+func BenchmarkXorBytesCTR1400Reference(b *testing.B) {
+	benchmarkXorBytesCTRReference(b, 1400)
+}

--- a/errors.go
+++ b/errors.go
@@ -18,6 +18,7 @@ var (
 	errTooShortRTCP                  = errors.New("packet is too short to be rtcp packet")
 	errPayloadDiffers                = errors.New("payload differs")
 	errStartedChannelUsedIncorrectly = errors.New("started channel used incorrectly, should only be closed")
+	errBadIVLength                   = errors.New("bad iv length in xorBytesCTR")
 
 	errStreamNotInited     = errors.New("stream has not been inited, unable to close")
 	errStreamAlreadyClosed = errors.New("stream is already closed")

--- a/srtp_test.go
+++ b/srtp_test.go
@@ -375,6 +375,7 @@ func BenchmarkEncryptRTP(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.SetBytes(int64(len(pktRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -399,6 +400,7 @@ func BenchmarkEncryptRTPInPlace(b *testing.B) {
 
 	buf := make([]byte, 0, len(pktRaw)+10)
 
+	b.SetBytes(int64(len(pktRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -430,6 +432,7 @@ func BenchmarkDecryptRTP(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.SetBytes(int64(len(encryptedRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -97,6 +97,7 @@ func BenchmarkWrite(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.SetBytes(int64(len(packetRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -146,6 +147,7 @@ func BenchmarkWriteRTP(b *testing.B) {
 
 	payload := make([]byte, 100)
 
+	b.SetBytes(int64(header.MarshalSize() + len(payload)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This avoids the allocation of a 512-byte buffer on each packet, which leads to a 30% to 50% speedup in the SRTP benchmaks.

Edit (28/04/2022): see https://github.com/pion/srtp/pull/76#issuecomment-1112323998 for updated benchmarks.

```
name                 old time/op    new time/op     delta
EncryptRTP-4           4.15µs ± 0%     2.85µs ± 1%  -31.38%  (p=0.000 n=8+7)
EncryptRTPInPlace-4    4.05µs ± 2%     2.75µs ± 0%  -32.19%  (p=0.000 n=7+8)
DecryptRTP-4           3.81µs ± 0%     2.02µs ± 1%  -47.01%  (p=0.000 n=8+8)
Write-4                4.23µs ± 1%     2.93µs ± 0%  -30.79%  (p=0.000 n=8+8)
WriteRTP-4             4.15µs ± 0%     2.86µs ± 1%  -31.10%  (p=0.000 n=7+8)

name                 old speed      new speed       delta
EncryptRTP-4         27.0MB/s ± 0%   39.3MB/s ± 1%  +45.71%  (p=0.000 n=8+7)
EncryptRTPInPlace-4  27.7MB/s ± 2%   40.8MB/s ± 0%  +47.46%  (p=0.000 n=7+8)
DecryptRTP-4         7.34MB/s ± 0%  13.86MB/s ± 1%  +88.73%  (p=0.000 n=8+8)
Write-4              26.5MB/s ± 1%   38.2MB/s ± 0%  +44.47%  (p=0.000 n=8+8)
WriteRTP-4           27.0MB/s ± 0%   39.2MB/s ± 1%  +45.16%  (p=0.000 n=7+8)

name                 old alloc/op   new alloc/op    delta
EncryptRTP-4             788B ± 0%       212B ± 0%  -73.10%  (p=0.000 n=8+8)
EncryptRTPInPlace-4      660B ± 0%        84B ± 0%  -87.27%  (p=0.000 n=8+8)
DecryptRTP-4             692B ± 0%       116B ± 0%  -83.24%  (p=0.000 n=8+8)
Write-4                  788B ± 0%       212B ± 0%  -73.10%  (p=0.000 n=8+8)
WriteRTP-4               788B ± 0%       212B ± 0%  -73.10%  (p=0.000 n=8+8)

name                 old allocs/op  new allocs/op   delta
EncryptRTP-4             7.00 ± 0%       6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
EncryptRTPInPlace-4      6.00 ± 0%       5.00 ± 0%  -16.67%  (p=0.000 n=8+8)
DecryptRTP-4             7.00 ± 0%       6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
Write-4                  7.00 ± 0%       6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
WriteRTP-4               7.00 ± 0%       6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
