### PR TITLE
Avoid growbuffer

### DIFF
--- a/srtp_test.go
+++ b/srtp_test.go
@@ -359,6 +359,7 @@ func BenchmarkEncryptRTP(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.SetBytes(int64(len(pktRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -383,6 +384,7 @@ func BenchmarkEncryptRTPInPlace(b *testing.B) {
 
 	buf := make([]byte, 0, len(pktRaw)+10)
 
+	b.SetBytes(int64(len(pktRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -414,6 +416,7 @@ func BenchmarkDecryptRTP(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.SetBytes(int64(len(encryptedRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/srtp_test.go
+++ b/srtp_test.go
@@ -347,13 +347,13 @@ func TestRTPReplayProtection(t *testing.T) {
 	}
 }
 
-func BenchmarkEncryptRTP(b *testing.B) {
+func benchmarkEncryptRTP(b *testing.B, size int) {
 	encryptContext, err := buildTestContext()
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	pkt := &rtp.Packet{Payload: make([]byte, 100)}
+	pkt := &rtp.Packet{Payload: make([]byte, size)}
 	pktRaw, err := pkt.Marshal()
 	if err != nil {
 		b.Fatal(err)
@@ -370,13 +370,25 @@ func BenchmarkEncryptRTP(b *testing.B) {
 	}
 }
 
-func BenchmarkEncryptRTPInPlace(b *testing.B) {
+func BenchmarkEncryptRTP14(b *testing.B) {
+	benchmarkEncryptRTP(b, 14)
+}
+
+func BenchmarkEncryptRTP140(b *testing.B) {
+	benchmarkEncryptRTP(b, 140)
+}
+
+func BenchmarkEncryptRTP1400(b *testing.B) {
+	benchmarkEncryptRTP(b, 1400)
+}
+
+func benchmarkEncryptRTPInPlace(b *testing.B, size int) {
 	encryptContext, err := buildTestContext()
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	pkt := &rtp.Packet{Payload: make([]byte, 100)}
+	pkt := &rtp.Packet{Payload: make([]byte, size)}
 	pktRaw, err := pkt.Marshal()
 	if err != nil {
 		b.Fatal(err)
@@ -393,6 +405,18 @@ func BenchmarkEncryptRTPInPlace(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkEncryptRTPInPlace14(b *testing.B) {
+	benchmarkEncryptRTPInPlace(b, 14)
+}
+
+func BenchmarkEncryptRTPInPlace140(b *testing.B) {
+	benchmarkEncryptRTPInPlace(b, 140)
+}
+
+func BenchmarkEncryptRTPInPlace1400(b *testing.B) {
+	benchmarkEncryptRTPInPlace(b, 1400)
 }
 
 func BenchmarkDecryptRTP(b *testing.B) {

--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -57,6 +57,7 @@ func BenchmarkWrite(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.SetBytes(int64(len(packetRaw)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -106,6 +107,7 @@ func BenchmarkWriteRTP(b *testing.B) {
 
 	payload := make([]byte, 100)
 
+	b.SetBytes(int64(header.MarshalSize() + len(payload)))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -21,7 +21,7 @@ func (c *noopConn) SetDeadline(t time.Time) error      { return nil }
 func (c *noopConn) SetReadDeadline(t time.Time) error  { return nil }
 func (c *noopConn) SetWriteDeadline(t time.Time) error { return nil }
 
-func BenchmarkWrite(b *testing.B) {
+func benchmarkWrite(b *testing.B, size int) {
 	conn := newNoopConn()
 
 	config := &Config{
@@ -49,7 +49,7 @@ func BenchmarkWrite(b *testing.B) {
 			Version: 2,
 			SSRC:    322,
 		},
-		Payload: make([]byte, 100),
+		Payload: make([]byte, size),
 	}
 
 	packetRaw, err := packet.Marshal()
@@ -75,7 +75,19 @@ func BenchmarkWrite(b *testing.B) {
 	}
 }
 
-func BenchmarkWriteRTP(b *testing.B) {
+func BenchmarkWrite14(b *testing.B) {
+	benchmarkWrite(b, 14)
+}
+
+func BenchmarkWrite140(b *testing.B) {
+	benchmarkWrite(b, 140)
+}
+
+func BenchmarkWrite1400(b *testing.B) {
+	benchmarkWrite(b, 1400)
+}
+
+func benchmarkWriteRTP(b *testing.B, size int) {
 	conn := &noopConn{
 		closed: make(chan struct{}),
 	}
@@ -105,7 +117,7 @@ func BenchmarkWriteRTP(b *testing.B) {
 		SSRC:    322,
 	}
 
-	payload := make([]byte, 100)
+	payload := make([]byte, size)
 
 	b.SetBytes(int64(header.MarshalSize() + len(payload)))
 	b.ResetTimer()
@@ -123,4 +135,16 @@ func BenchmarkWriteRTP(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+}
+
+func BenchmarkWriteRTP14(b *testing.B) {
+	benchmarkWriteRTP(b, 14)
+}
+
+func BenchmarkWriteRTP140(b *testing.B) {
+	benchmarkWriteRTP(b, 140)
+}
+
+func BenchmarkWriteRTP1400(b *testing.B) {
+	benchmarkWriteRTP(b, 1400)
 }


### PR DESCRIPTION
Allocation decreases by 70% for large packets.  CPU time remains unchanged for small packets, decreases slightly for large packets.
```

name            old time/op    new time/op    delta
Write14-4         2.73µs ± 0%    2.72µs ± 0%   -0.39%  (p=0.007 n=7+8)
Write140-4        3.16µs ± 0%    3.13µs ± 2%   -1.16%  (p=0.016 n=8+8)
Write1400-4       8.00µs ± 0%    7.58µs ± 0%   -5.24%  (p=0.000 n=8+8)
WriteRTP14-4      2.68µs ± 1%    2.67µs ± 0%   -0.36%  (p=0.035 n=8+7)
WriteRTP140-4     3.11µs ± 1%    3.08µs ± 1%   -0.98%  (p=0.005 n=7+8)
WriteRTP1400-4    7.97µs ± 0%    7.54µs ± 0%   -5.39%  (p=0.000 n=7+8)

name            old speed      new speed      delta
Write14-4       9.50MB/s ± 1%  9.55MB/s ± 0%   +0.51%  (p=0.007 n=8+8)
Write140-4      48.0MB/s ± 0%  48.6MB/s ± 2%   +1.18%  (p=0.016 n=8+8)
Write1400-4      176MB/s ± 0%   186MB/s ± 0%   +5.53%  (p=0.000 n=8+8)
WriteRTP14-4    9.71MB/s ± 1%  9.75MB/s ± 0%   +0.36%  (p=0.036 n=8+7)
WriteRTP140-4   48.9MB/s ± 1%  49.4MB/s ± 1%   +1.00%  (p=0.008 n=7+8)
WriteRTP1400-4   177MB/s ± 0%   187MB/s ± 0%   +5.70%  (p=0.000 n=7+8)

name            old alloc/op   new alloc/op   delta
Write14-4           708B ± 0%      660B ± 0%   -6.78%  (p=0.000 n=8+8)
Write140-4          836B ± 0%      660B ± 0%  -21.05%  (p=0.000 n=8+8)
Write1400-4       2.20kB ± 0%    0.66kB ± 0%  -69.95%  (p=0.000 n=8+8)
WriteRTP14-4        708B ± 0%      660B ± 0%   -6.78%  (p=0.000 n=8+8)
WriteRTP140-4       836B ± 0%      660B ± 0%  -21.05%  (p=0.000 n=8+8)
WriteRTP1400-4    2.20kB ± 0%    0.66kB ± 0%  -69.95%  (p=0.000 n=8+8)

name            old allocs/op  new allocs/op  delta
Write14-4           7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
Write140-4          7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
Write1400-4         7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
WriteRTP14-4        7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
WriteRTP140-4       7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
WriteRTP1400-4      7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=8+8)
```