### PR TITLE
Support export/import ROC and Index

### DIFF
--- a/context.go
+++ b/context.go
@@ -341,3 +341,33 @@ func (c *Context) getSRTCPSSRCState(ssrc uint32) *srtcpSSRCState {
 	c.srtcpSSRCStates[ssrc] = s
 	return s
 }
+
+// ROC returns SRTP rollover counter value of specified SSRC.
+func (c *Context) ROC(ssrc uint32) (uint32, bool) {
+	s, ok := c.srtpSSRCStates[ssrc]
+	if !ok {
+		return 0, false
+	}
+	return s.rolloverCounter, true
+}
+
+// SetROC sets SRTP rollover counter value of specified SSRC.
+func (c *Context) SetROC(ssrc uint32, roc uint32) {
+	s := c.getSRTPSSRCState(ssrc)
+	s.rolloverCounter = roc
+}
+
+// Index returns SRTCP index value of specified SSRC.
+func (c *Context) Index(ssrc uint32) (uint32, bool) {
+	s, ok := c.srtcpSSRCStates[ssrc]
+	if !ok {
+		return 0, false
+	}
+	return s.srtcpIndex, true
+}
+
+// SetIndex sets SRTCP index value of specified SSRC.
+func (c *Context) SetIndex(ssrc uint32, index uint32) {
+	s := c.getSRTCPSSRCState(ssrc)
+	s.srtcpIndex = index % maxSRTCPIndex
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,43 @@
+package srtp
+
+import (
+	"testing"
+)
+
+func TestContextROC(t *testing.T) {
+	c, err := CreateContext(make([]byte, 16), make([]byte, 14), cipherContextAlgo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := c.ROC(123); ok {
+		t.Error("ROC must return false for unused SSRC")
+	}
+	c.SetROC(123, 100)
+	roc, ok := c.ROC(123)
+	if !ok {
+		t.Fatal("ROC must return true for used SSRC")
+	}
+	if roc != 100 {
+		t.Errorf("ROC is set to 100, but returned %d", roc)
+	}
+}
+
+func TestContextIndex(t *testing.T) {
+	c, err := CreateContext(make([]byte, 16), make([]byte, 14), cipherContextAlgo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := c.Index(123); ok {
+		t.Error("Index must return false for unused SSRC")
+	}
+	c.SetIndex(123, 100)
+	index, ok := c.Index(123)
+	if !ok {
+		t.Fatal("Index must return true for used SSRC")
+	}
+	if index != 100 {
+		t.Errorf("Index is set to 100, but returned %d", index)
+	}
+}


### PR DESCRIPTION
Add method to export and import SRTP ROC and SRTCP Index to support
synchronizing these values among distributed instances.
