### PR TITLE
Add details of duplicated error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,21 @@ package srtp
 
 import (
 	"errors"
+	"fmt"
 )
 
 var errDuplicated = errors.New("duplicated packet")
+
+type errorDuplicated struct {
+	Proto string // srtp or srtcp
+	SSRC  uint32
+	Index uint32 // sequence number or index
+}
+
+func (e *errorDuplicated) Error() string {
+	return fmt.Sprintf("%s ssrc=%d index=%d: %v", e.Proto, e.SSRC, e.Index, errDuplicated)
+}
+
+func (e *errorDuplicated) Unwrap() error {
+	return errDuplicated
+}

--- a/session.go
+++ b/session.go
@@ -130,13 +130,13 @@ func (s *session) start(localMasterKey, localMasterSalt, remoteMasterKey, remote
 			i, err = s.nextConn.Read(b)
 			if err != nil {
 				if err != io.EOF {
-					s.log.Errorf("srtp: %s", err.Error())
+					s.log.Error(err.Error())
 				}
 				return
 			}
 
 			if err = child.decrypt(b[:i]); err != nil {
-				s.log.Infof("%v \n", err)
+				s.log.Info(err.Error())
 			}
 		}
 	}()

--- a/srtcp.go
+++ b/srtcp.go
@@ -25,7 +25,7 @@ func (c *Context) decryptRTCP(dst, encrypted []byte) ([]byte, error) {
 	s := c.getSRTCPSSRCState(ssrc)
 	markAsValid, ok := s.replayDetector.Check(uint64(index))
 	if !ok {
-		return nil, errDuplicated
+		return nil, &errorDuplicated{Proto: "srtcp", SSRC: ssrc, Index: index}
 	}
 
 	out, err := c.cipher.decryptRTCP(out, encrypted, index, ssrc)

--- a/srtcp_test.go
+++ b/srtcp_test.go
@@ -3,6 +3,7 @@ package srtp
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/pion/rtcp"
@@ -178,10 +179,10 @@ func TestRTCPReplayDetectorSeparation(t *testing.T) {
 	}
 	assert.Equal(decryptResult2, rtcpTestDecrypted2, "RTCP failed to decrypt")
 
-	if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket1, nil); err != errDuplicated {
+	if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket1, nil); !errors.Is(err, errDuplicated) {
 		t.Errorf("Was able to decrypt duplicated RTCP packet")
 	}
-	if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket2, nil); err != errDuplicated {
+	if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket2, nil); !errors.Is(err, errDuplicated) {
 		t.Errorf("Was able to decrypt duplicated RTCP packet")
 	}
 }

--- a/srtp.go
+++ b/srtp.go
@@ -10,7 +10,9 @@ func (c *Context) decryptRTP(dst, ciphertext []byte, header *rtp.Header) ([]byte
 
 	markAsValid, ok := s.replayDetector.Check(uint64(header.SequenceNumber))
 	if !ok {
-		return nil, errDuplicated
+		return nil, &errorDuplicated{
+			Proto: "srtp", SSRC: header.SSRC, Index: uint32(header.SequenceNumber),
+		}
 	}
 
 	dst = growBufferSize(dst, len(ciphertext)-c.cipher.authTagLen())

--- a/srtp_test.go
+++ b/srtp_test.go
@@ -2,6 +2,7 @@ package srtp
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/pion/rtp"
@@ -343,7 +344,7 @@ func TestRTPReplayProtection(t *testing.T) {
 		assert.Equalf(actualDecrypted, decryptedRaw, "RTP packet with SeqNum invalid decryption: %d", testCase.sequenceNumber)
 
 		_, errReplay := decryptContext.DecryptRTP(decryptInput, decryptInput, decryptHeader)
-		if errReplay != errDuplicated {
+		if !errors.Is(errReplay, errDuplicated) {
 			t.Errorf("Replayed packet must be errored with %v, got %v", errDuplicated, errReplay)
 		}
 	}


### PR DESCRIPTION
It was not clear which stream caused error in the session.
Add details of duplication error.

----

I'm currently facing that `srtp.session` created by pion/webrtc reports a lot of `duplicated packet` when publishing media to browsers. I guess there is a bug around handling multiplexed packets. (found a bug > #90)