### PR TITLE
Added read timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Novel Corpse](https://github.com/NovelCorpse)
 * [Jerko Steiner](https://github.com/jeremija)
 * [Juliusz Chroboczek](https://github.com/jech)
+* [Threadnaught](https://github.com/Threadnaught/)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/stream_srtcp.go
+++ b/stream_srtcp.go
@@ -3,6 +3,7 @@ package srtp
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/pion/rtcp"
 	"github.com/pion/transport/packetio"
@@ -110,6 +111,11 @@ func (r *ReadStreamSRTCP) init(child streamSession, ssrc uint32) error {
 // GetSSRC returns the SSRC we are demuxing for
 func (r *ReadStreamSRTCP) GetSSRC() uint32 {
 	return r.ssrc
+}
+
+// SetReadDeadline sets the max amount of time the stream will block before returning. 0 is forever.
+func (r *ReadStreamSRTCP) SetReadDeadline(t time.Time) error {
+	return r.buffer.SetReadDeadline(t)
 }
 
 // WriteStreamSRTCP is stream for a single Session that is used to encrypt RTCP

--- a/stream_srtp.go
+++ b/stream_srtp.go
@@ -3,6 +3,7 @@ package srtp
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/pion/rtp"
 	"github.com/pion/transport/packetio"
@@ -112,6 +113,11 @@ func (r *ReadStreamSRTP) Close() error {
 // GetSSRC returns the SSRC we are demuxing for
 func (r *ReadStreamSRTP) GetSSRC() uint32 {
 	return r.ssrc
+}
+
+// SetReadDeadline sets the max amount of time the stream will block before returning. 0 is forever.
+func (r *ReadStreamSRTP) SetReadDeadline(t time.Time) error {
+	return r.buffer.SetReadDeadline(t)
 }
 
 // WriteStreamSRTP is stream for a single Session that is used to encrypt RTP


### PR DESCRIPTION
#### Added timeouts to ReadStreamSRTCP and ReadStreamSRTP

As part of a project that I'm currently working on I needed webrtc to be able to timeout during a channel read. I discussed how to do this with Sean and he suggested adding a function here that calls through to the underlying `buffer. SetReadDeadline`. I have another change ready to add to the WebRTC once this is approved.

