### PR TITLE
Fix panic when calling SetReadDeadline

### DIFF
--- a/stream_srtcp.go
+++ b/stream_srtcp.go
@@ -66,7 +66,12 @@ func (r *ReadStreamSRTCP) Read(buf []byte) (int, error) {
 // SetReadDeadline sets the deadline for the Read operation.
 // Setting to zero means no deadline.
 func (r *ReadStreamSRTCP) SetReadDeadline(t time.Time) error {
-	return r.buffer.(*packetio.Buffer).SetReadDeadline(t)
+	if b, ok := r.buffer.(interface {
+		SetReadDeadline(time.Time) error
+	}); ok {
+		return b.SetReadDeadline(t)
+	}
+	return nil
 }
 
 // Close removes the ReadStream from the session and cleans up any associated state

--- a/stream_srtp.go
+++ b/stream_srtp.go
@@ -96,7 +96,12 @@ func (r *ReadStreamSRTP) ReadRTP(buf []byte) (int, *rtp.Header, error) {
 // SetReadDeadline sets the deadline for the Read operation.
 // Setting to zero means no deadline.
 func (r *ReadStreamSRTP) SetReadDeadline(t time.Time) error {
-	return r.buffer.(*packetio.Buffer).SetReadDeadline(t)
+	if b, ok := r.buffer.(interface {
+		SetReadDeadline(time.Time) error
+	}); ok {
+		return b.SetReadDeadline(t)
+	}
+	return nil
 }
 
 // Close removes the ReadStream from the session and cleans up any associated state


### PR DESCRIPTION
#### Description
The io.ReadWriteCloser doesn't include this method, should make sure it
exists before calling it.

After integrated the `webrtc.SettingEngine.BufferFactory`, this issue arises.