### PR TITLE
Fix SRTCP decrypt for AEAD_AES_GCM

### DIFF
--- a/protection_profile.go
+++ b/protection_profile.go
@@ -44,6 +44,17 @@ func (p ProtectionProfile) authTagLen() (int, error) {
 	}
 }
 
+func (p ProtectionProfile) aeadAuthTagLen() (int, error) {
+	switch p {
+	case ProtectionProfileAes128CmHmacSha1_80:
+		return (&srtpCipherAesCmHmacSha1{}).aeadAuthTagLen(), nil
+	case ProtectionProfileAeadAes128Gcm:
+		return (&srtpCipherAeadAesGcm{}).aeadAuthTagLen(), nil
+	default:
+		return 0, fmt.Errorf("%w: %#v", errNoSuchSRTPProfile, p)
+	}
+}
+
 func (p ProtectionProfile) authKeyLen() (int, error) {
 	switch p {
 	case ProtectionProfileAes128CmHmacSha1_80:

--- a/srtcp_test.go
+++ b/srtcp_test.go
@@ -10,46 +10,170 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func rtcpTestMasterKey() []byte {
-	return []byte{0xfd, 0xa6, 0x25, 0x95, 0xd7, 0xf6, 0x92, 0x6f, 0x7d, 0x9c, 0x02, 0x4c, 0xc9, 0x20, 0x9f, 0x34}
-}
-
-func rtcpTestMasterSalt() []byte {
-	return []byte{0xa9, 0x65, 0x19, 0x85, 0x54, 0x0b, 0x47, 0xbe, 0x2f, 0x27, 0xa8, 0xb8, 0x81, 0x23}
-}
-
-type rtcpTestCase struct {
+type rtcpTestPacket struct {
 	ssrc      uint32
 	index     uint32
+	pktType   rtcp.PacketType
 	encrypted []byte
 	decrypted []byte
 }
 
-func rtcpTestCases() []rtcpTestCase {
-	return []rtcpTestCase{
-		{
-			ssrc:      0x66ef91ff,
-			index:     0,
-			encrypted: []byte{0x80, 0xc8, 0x00, 0x06, 0x66, 0xef, 0x91, 0xff, 0xcd, 0x34, 0xc5, 0x78, 0xb2, 0x8b, 0xe1, 0x6b, 0xc5, 0x09, 0xd5, 0x77, 0xe4, 0xce, 0x5f, 0x20, 0x80, 0x21, 0xbd, 0x66, 0x74, 0x65, 0xe9, 0x5f, 0x49, 0xe5, 0xf5, 0xc0, 0x68, 0x4e, 0xe5, 0x6a, 0x78, 0x07, 0x75, 0x46, 0xed, 0x90, 0xf6, 0xdc, 0x9d, 0xef, 0x3b, 0xdf, 0xf2, 0x79, 0xa9, 0xd8, 0x80, 0x00, 0x00, 0x01, 0x60, 0xc0, 0xae, 0xb5, 0x6f, 0x40, 0x88, 0x0e, 0x28, 0xba},
-			decrypted: []byte{0x80, 0xc8, 0x00, 0x06, 0x66, 0xef, 0x91, 0xff, 0xdf, 0x48, 0x80, 0xdd, 0x61, 0xa6, 0x2e, 0xd3, 0xd8, 0xbc, 0xde, 0xbe, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x16, 0x04, 0x81, 0xca, 0x00, 0x06, 0x66, 0xef, 0x91, 0xff, 0x01, 0x10, 0x52, 0x6e, 0x54, 0x35, 0x43, 0x6d, 0x4a, 0x68, 0x7a, 0x79, 0x65, 0x74, 0x41, 0x78, 0x77, 0x2b, 0x00, 0x00},
+type rtcpTestCase struct {
+	algo       ProtectionProfile
+	masterKey  []byte
+	masterSalt []byte
+	packets    []rtcpTestPacket
+}
+
+func rtcpTestCasesSingle() map[string]rtcpTestCase {
+	return map[string]rtcpTestCase{
+		"AEAD_AES_128_GCM": {
+			algo:       ProtectionProfileAeadAes128Gcm,
+			masterKey:  []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f},
+			masterSalt: []byte{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab},
+			packets: []rtcpTestPacket{
+				{
+					ssrc:    0xcafebabe,
+					index:   0,
+					pktType: rtcp.TypeSenderReport,
+					encrypted: []byte{
+						0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+						0xc9, 0x8b, 0x8b, 0x5d, 0xf0, 0x39, 0x2a, 0x55,
+						0x85, 0x2b, 0x6c, 0x21, 0xac, 0x8e, 0x70, 0x25,
+						0xc5, 0x2c, 0x6f, 0xbe, 0xa2, 0xb3, 0xb4, 0x46,
+						0xea, 0x31, 0x12, 0x3b, 0xa8, 0x8c, 0xe6, 0x1e,
+						0x80, 0x00, 0x00, 0x01,
+					},
+					decrypted: []byte{
+						0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+						0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+						0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+					},
+				},
+			},
 		},
-		{
-			ssrc:      0x11111111,
-			index:     0,
-			encrypted: []byte{0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11, 0x17, 0x8c, 0x15, 0xf1, 0x4b, 0x11, 0xda, 0xf5, 0x74, 0x53, 0x86, 0x2b, 0xc9, 0x07, 0x29, 0x40, 0xbf, 0x22, 0xf6, 0x46, 0x11, 0xa4, 0xc1, 0x3a, 0xff, 0x5a, 0xbd, 0xd0, 0xf8, 0x8b, 0x38, 0xe4, 0x95, 0x38, 0x5d, 0xcf, 0x1b, 0xf5, 0x27, 0x77, 0xfb, 0xdb, 0x3f, 0x10, 0x68, 0x99, 0xd8, 0xad, 0x80, 0x00, 0x00, 0x01, 0x34, 0x3c, 0x2e, 0x83, 0x17, 0x13, 0x93, 0x69, 0xcf, 0xc0},
-			decrypted: []byte{0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11, 0xdf, 0x48, 0x80, 0xdd, 0x61, 0xa6, 0x2e, 0xd3, 0xd8, 0xbc, 0xde, 0xbe, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x16, 0x04, 0x81, 0xca, 0x00, 0x06, 0x66, 0xef, 0x91, 0xff, 0x01, 0x10, 0x52, 0x6e, 0x54, 0x35, 0x43, 0x6d, 0x4a, 0x68, 0x7a, 0x79, 0x65, 0x74, 0x41, 0x78, 0x77, 0x2b, 0x00, 0x00},
+		"AES_128_CM_HMAC_SHA1_80": {
+			algo:       ProtectionProfileAes128CmHmacSha1_80,
+			masterKey:  []byte{0xfd, 0xa6, 0x25, 0x95, 0xd7, 0xf6, 0x92, 0x6f, 0x7d, 0x9c, 0x02, 0x4c, 0xc9, 0x20, 0x9f, 0x34},
+			masterSalt: []byte{0xa9, 0x65, 0x19, 0x85, 0x54, 0x0b, 0x47, 0xbe, 0x2f, 0x27, 0xa8, 0xb8, 0x81, 0x23},
+			packets: []rtcpTestPacket{
+				{
+					ssrc:    0x66ef91ff,
+					index:   0,
+					pktType: rtcp.TypeSenderReport,
+					encrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x66, 0xef, 0x91, 0xff,
+						0xcd, 0x34, 0xc5, 0x78, 0xb2, 0x8b, 0xe1, 0x6b,
+						0xc5, 0x09, 0xd5, 0x77, 0xe4, 0xce, 0x5f, 0x20,
+						0x80, 0x21, 0xbd, 0x66, 0x74, 0x65, 0xe9, 0x5f,
+						0x49, 0xe5, 0xf5, 0xc0, 0x68, 0x4e, 0xe5, 0x6a,
+						0x78, 0x07, 0x75, 0x46, 0xed, 0x90, 0xf6, 0xdc,
+						0x9d, 0xef, 0x3b, 0xdf, 0xf2, 0x79, 0xa9, 0xd8,
+						0x80, 0x00, 0x00, 0x01, 0x60, 0xc0, 0xae, 0xb5,
+						0x6f, 0x40, 0x88, 0x0e, 0x28, 0xba,
+					},
+					decrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x66, 0xef, 0x91, 0xff,
+						0xdf, 0x48, 0x80, 0xdd, 0x61, 0xa6, 0x2e, 0xd3,
+						0xd8, 0xbc, 0xde, 0xbe, 0x00, 0x00, 0x00, 0x09,
+						0x00, 0x00, 0x16, 0x04, 0x81, 0xca, 0x00, 0x06,
+						0x66, 0xef, 0x91, 0xff, 0x01, 0x10, 0x52, 0x6e,
+						0x54, 0x35, 0x43, 0x6d, 0x4a, 0x68, 0x7a, 0x79,
+						0x65, 0x74, 0x41, 0x78, 0x77, 0x2b, 0x00, 0x00,
+					},
+				},
+				{
+					ssrc:    0x11111111,
+					index:   0,
+					pktType: rtcp.TypeSenderReport,
+					encrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11,
+						0x17, 0x8c, 0x15, 0xf1, 0x4b, 0x11, 0xda, 0xf5,
+						0x74, 0x53, 0x86, 0x2b, 0xc9, 0x07, 0x29, 0x40,
+						0xbf, 0x22, 0xf6, 0x46, 0x11, 0xa4, 0xc1, 0x3a,
+						0xff, 0x5a, 0xbd, 0xd0, 0xf8, 0x8b, 0x38, 0xe4,
+						0x95, 0x38, 0x5d, 0xcf, 0x1b, 0xf5, 0x27, 0x77,
+						0xfb, 0xdb, 0x3f, 0x10, 0x68, 0x99, 0xd8, 0xad,
+						0x80, 0x00, 0x00, 0x01, 0x34, 0x3c, 0x2e, 0x83,
+						0x17, 0x13, 0x93, 0x69, 0xcf, 0xc0,
+					},
+					decrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11,
+						0xdf, 0x48, 0x80, 0xdd, 0x61, 0xa6, 0x2e, 0xd3,
+						0xd8, 0xbc, 0xde, 0xbe, 0x00, 0x00, 0x00, 0x09,
+						0x00, 0x00, 0x16, 0x04, 0x81, 0xca, 0x00, 0x06,
+						0x66, 0xef, 0x91, 0xff, 0x01, 0x10, 0x52, 0x6e,
+						0x54, 0x35, 0x43, 0x6d, 0x4a, 0x68, 0x7a, 0x79,
+						0x65, 0x74, 0x41, 0x78, 0x77, 0x2b, 0x00, 0x00,
+					},
+				},
+			},
 		},
-		{
-			ssrc:      0x11111111,
-			index:     0x7ffffffe, // Upper boundary of index
-			encrypted: []byte{0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11, 0x17, 0x8c, 0x15, 0xf1, 0x4b, 0x11, 0xda, 0xf5, 0x74, 0x53, 0x86, 0x2b, 0xc9, 0x07, 0x29, 0x40, 0xbf, 0x22, 0xf6, 0x46, 0x11, 0xa4, 0xc1, 0x3a, 0xff, 0x5a, 0xbd, 0xd0, 0xf8, 0x8b, 0x38, 0xe4, 0x95, 0x38, 0x5d, 0xcf, 0x1b, 0xf5, 0x27, 0x77, 0xfb, 0xdb, 0x3f, 0x10, 0x68, 0x99, 0xd8, 0xad, 0xff, 0xff, 0xff, 0xff, 0x5a, 0x99, 0xce, 0xed, 0x9f, 0x2e, 0x4d, 0x9d, 0xfa, 0x97},
-			decrypted: []byte{0x80, 0xc8, 0x0, 0x6, 0x11, 0x11, 0x11, 0x11, 0x4, 0x99, 0x47, 0x53, 0xc4, 0x1e, 0xb9, 0xde, 0x52, 0xa3, 0x1d, 0x77, 0x2f, 0xff, 0xcc, 0x75, 0xbb, 0x6a, 0x29, 0xb8, 0x1, 0xb7, 0x2e, 0x4b, 0x4e, 0xcb, 0xa4, 0x81, 0x2d, 0x46, 0x4, 0x5e, 0x86, 0x90, 0x17, 0x4f, 0x4d, 0x78, 0x2f, 0x58, 0xb8, 0x67, 0x91, 0x89, 0xe3, 0x61, 0x1, 0x7d},
-		},
-		{
-			ssrc:      0x11111111,
-			index:     0x7fffffff, // Will be wrapped to 0
-			encrypted: []byte{0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11, 0x17, 0x8c, 0x15, 0xf1, 0x4b, 0x11, 0xda, 0xf5, 0x74, 0x53, 0x86, 0x2b, 0xc9, 0x07, 0x29, 0x40, 0xbf, 0x22, 0xf6, 0x46, 0x11, 0xa4, 0xc1, 0x3a, 0xff, 0x5a, 0xbd, 0xd0, 0xf8, 0x8b, 0x38, 0xe4, 0x95, 0x38, 0x5d, 0xcf, 0x1b, 0xf5, 0x27, 0x77, 0xfb, 0xdb, 0x3f, 0x10, 0x68, 0x99, 0xd8, 0xad, 0x80, 0x00, 0x00, 0x00, 0x7d, 0x51, 0xf8, 0x0e, 0x56, 0x40, 0x72, 0x7b, 0x9e, 0x02},
-			decrypted: []byte{0x80, 0xc8, 0x0, 0x6, 0x11, 0x11, 0x11, 0x11, 0xda, 0xb5, 0xe0, 0x56, 0x9a, 0x4a, 0x74, 0xed, 0x8a, 0x54, 0xc, 0xcf, 0xd5, 0x9, 0xb1, 0x40, 0x1, 0x42, 0xc3, 0x9a, 0x76, 0x0, 0xa9, 0xd4, 0xf7, 0x29, 0x9e, 0x51, 0xfb, 0x3c, 0xc1, 0x74, 0x72, 0xf9, 0x52, 0xb1, 0x92, 0x31, 0xca, 0x22, 0xab, 0x3e, 0xc5, 0x5f, 0x83, 0x34, 0xf0, 0x28},
+	}
+}
+
+func rtcpTestCases() map[string]rtcpTestCase {
+	single := rtcpTestCasesSingle()
+	return map[string]rtcpTestCase{
+		"AEAD_AES_128_GCM": single["AEAD_AES_128_GCM"],
+		"AES_128_CM_HMAC_SHA1_80": {
+			algo:       ProtectionProfileAes128CmHmacSha1_80,
+			masterKey:  single["AES_128_CM_HMAC_SHA1_80"].masterKey,
+			masterSalt: single["AES_128_CM_HMAC_SHA1_80"].masterSalt,
+			packets: []rtcpTestPacket{
+				single["AES_128_CM_HMAC_SHA1_80"].packets[0],
+				single["AES_128_CM_HMAC_SHA1_80"].packets[1],
+				{
+					ssrc:    0x11111111,
+					index:   0x7ffffffe, // Upper boundary of index
+					pktType: rtcp.TypeSenderReport,
+					encrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11,
+						0x17, 0x8c, 0x15, 0xf1, 0x4b, 0x11, 0xda, 0xf5,
+						0x74, 0x53, 0x86, 0x2b, 0xc9, 0x07, 0x29, 0x40,
+						0xbf, 0x22, 0xf6, 0x46, 0x11, 0xa4, 0xc1, 0x3a,
+						0xff, 0x5a, 0xbd, 0xd0, 0xf8, 0x8b, 0x38, 0xe4,
+						0x95, 0x38, 0x5d, 0xcf, 0x1b, 0xf5, 0x27, 0x77,
+						0xfb, 0xdb, 0x3f, 0x10, 0x68, 0x99, 0xd8, 0xad,
+						0xff, 0xff, 0xff, 0xff, 0x5a, 0x99, 0xce, 0xed,
+						0x9f, 0x2e, 0x4d, 0x9d, 0xfa, 0x97,
+					},
+					decrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11,
+						0x04, 0x99, 0x47, 0x53, 0xc4, 0x1e, 0xb9, 0xde,
+						0x52, 0xa3, 0x1d, 0x77, 0x2f, 0xff, 0xcc, 0x75,
+						0xbb, 0x6a, 0x29, 0xb8, 0x01, 0xb7, 0x2e, 0x4b,
+						0x4e, 0xcb, 0xa4, 0x81, 0x2d, 0x46, 0x04, 0x5e,
+						0x86, 0x90, 0x17, 0x4f, 0x4d, 0x78, 0x2f, 0x58,
+						0xb8, 0x67, 0x91, 0x89, 0xe3, 0x61, 0x01, 0x7d,
+					},
+				},
+				{
+					ssrc:    0x11111111,
+					index:   0x7fffffff, // Will be wrapped to 0
+					pktType: rtcp.TypeSenderReport,
+					encrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11,
+						0x17, 0x8c, 0x15, 0xf1, 0x4b, 0x11, 0xda, 0xf5,
+						0x74, 0x53, 0x86, 0x2b, 0xc9, 0x07, 0x29, 0x40,
+						0xbf, 0x22, 0xf6, 0x46, 0x11, 0xa4, 0xc1, 0x3a,
+						0xff, 0x5a, 0xbd, 0xd0, 0xf8, 0x8b, 0x38, 0xe4,
+						0x95, 0x38, 0x5d, 0xcf, 0x1b, 0xf5, 0x27, 0x77,
+						0xfb, 0xdb, 0x3f, 0x10, 0x68, 0x99, 0xd8, 0xad,
+						0x80, 0x00, 0x00, 0x00, 0x7d, 0x51, 0xf8, 0x0e,
+						0x56, 0x40, 0x72, 0x7b, 0x9e, 0x02,
+					},
+					decrypted: []byte{
+						0x80, 0xc8, 0x00, 0x06, 0x11, 0x11, 0x11, 0x11,
+						0xda, 0xb5, 0xe0, 0x56, 0x9a, 0x4a, 0x74, 0xed,
+						0x8a, 0x54, 0x0c, 0xcf, 0xd5, 0x09, 0xb1, 0x40,
+						0x01, 0x42, 0xc3, 0x9a, 0x76, 0x00, 0xa9, 0xd4,
+						0xf7, 0x29, 0x9e, 0x51, 0xfb, 0x3c, 0xc1, 0x74,
+						0x72, 0xf9, 0x52, 0xb1, 0x92, 0x31, 0xca, 0x22,
+						0xab, 0x3e, 0xc5, 0x5f, 0x83, 0x34, 0xf0, 0x28,
+					},
+				},
+			},
 		},
 	}
 }
@@ -63,182 +187,228 @@ func TestRTCPLifecycle(t *testing.T) {
 	for name, option := range options {
 		option := option
 		t.Run(name, func(t *testing.T) {
-			assert := assert.New(t)
-			encryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo, option...)
-			if err != nil {
-				t.Errorf("CreateContext failed: %v", err)
-			}
+			for caseName, testCase := range rtcpTestCases() {
+				testCase := testCase
+				t.Run(caseName, func(t *testing.T) {
+					if testCase.algo == ProtectionProfileAeadAes128Gcm {
+						t.Skip("FIXME: DecryptRTCP(nil, input, nil) for ProtectionProfileAeadAes128Gcm changes input data")
+					}
+					assert := assert.New(t)
+					encryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo, option...)
+					if err != nil {
+						t.Errorf("CreateContext failed: %v", err)
+					}
 
-			decryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo, option...)
-			if err != nil {
-				t.Errorf("CreateContext failed: %v", err)
-			}
+					decryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo, option...)
+					if err != nil {
+						t.Errorf("CreateContext failed: %v", err)
+					}
 
-			for _, testCase := range rtcpTestCases() {
-				decryptResult, err := decryptContext.DecryptRTCP(nil, testCase.encrypted, nil)
-				if err != nil {
-					t.Error(err)
-				}
-				assert.Equal(decryptResult, testCase.decrypted, "RTCP failed to decrypt")
+					for _, pkt := range testCase.packets {
+						decryptResult, err := decryptContext.DecryptRTCP(nil, pkt.encrypted, nil)
+						if err != nil {
+							t.Error(err)
+						}
+						assert.Equal(pkt.decrypted, decryptResult, "RTCP failed to decrypt")
 
-				encryptContext.SetIndex(testCase.ssrc, testCase.index)
-				encryptResult, err := encryptContext.EncryptRTCP(nil, testCase.decrypted, nil)
-				if err != nil {
-					t.Error(err)
-				}
-				assert.Equal(encryptResult, testCase.encrypted, "RTCP failed to encrypt")
+						encryptContext.SetIndex(pkt.ssrc, pkt.index)
+						encryptResult, err := encryptContext.EncryptRTCP(nil, pkt.decrypted, nil)
+						if err != nil {
+							t.Error(err)
+						}
+						assert.Equal(pkt.encrypted, encryptResult, "RTCP failed to encrypt")
+					}
+				})
 			}
 		})
 	}
 }
 
 func TestRTCPLifecycleInPlace(t *testing.T) {
-	assert := assert.New(t)
-	authTagLen, err := ProtectionProfileAes128CmHmacSha1_80.authTagLen()
-	assert.NoError(err)
+	for caseName, testCase := range rtcpTestCases() {
+		testCase := testCase
+		t.Run(caseName, func(t *testing.T) {
+			if testCase.algo == ProtectionProfileAeadAes128Gcm {
+				t.Skip("ProtectionProfileAeadAes128Gcm implementation currently doesn't support in-place encrypt/decrypt")
+			}
+			assert := assert.New(t)
+			authTagLen, err := testCase.algo.authTagLen()
+			assert.NoError(err)
 
-	encryptHeader := &rtcp.Header{}
-	encryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo)
-	if err != nil {
-		t.Errorf("CreateContext failed: %v", err)
-	}
+			aeadAuthTagLen, err := testCase.algo.aeadAuthTagLen()
+			assert.NoError(err)
 
-	decryptHeader := &rtcp.Header{}
-	decryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo)
-	if err != nil {
-		t.Errorf("CreateContext failed: %v", err)
-	}
+			encryptHeader := &rtcp.Header{}
+			encryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo)
+			if err != nil {
+				t.Errorf("CreateContext failed: %v", err)
+			}
 
-	for _, testCase := range rtcpTestCases() {
-		// Copy packet, asserts that everything was done in place
-		decryptInput := append([]byte{}, testCase.encrypted...)
+			decryptHeader := &rtcp.Header{}
+			decryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo)
+			if err != nil {
+				t.Errorf("CreateContext failed: %v", err)
+			}
 
-		actualDecrypted, err := decryptContext.DecryptRTCP(decryptInput, decryptInput, decryptHeader)
-		switch {
-		case err != nil:
-			t.Error(err)
-		case decryptHeader.Type != rtcp.TypeSenderReport:
-			t.Fatal("DecryptRTCP failed to populate input rtcp.Header")
-		case !bytes.Equal(decryptInput[:len(decryptInput)-(authTagLen+srtcpIndexSize)], actualDecrypted):
-			t.Fatal("DecryptRTP failed to decrypt in place")
-		}
+			for _, pkt := range testCase.packets {
+				// Copy packet, asserts that everything was done in place
+				decryptInput := append([]byte{}, pkt.encrypted...)
 
-		assert.Equal(actualDecrypted, testCase.decrypted, "RTCP failed to decrypt")
+				actualDecrypted, err := decryptContext.DecryptRTCP(decryptInput, decryptInput, decryptHeader)
+				switch {
+				case err != nil:
+					t.Error(err)
+				case decryptHeader.Type != pkt.pktType:
+					t.Fatalf("DecryptRTCP failed to populate input rtcp.Header, expected: %d, got %d", pkt.pktType, decryptHeader.Type)
+				case !bytes.Equal(decryptInput[:len(decryptInput)-(authTagLen+aeadAuthTagLen+srtcpIndexSize)], actualDecrypted):
+					t.Fatalf("DecryptRTP failed to decrypt in place\nexpected: %v\n     got: %v", decryptInput[:len(decryptInput)-(authTagLen+srtcpIndexSize)], actualDecrypted)
+				}
+				assert.Equal(decryptInput[:len(decryptInput)-(authTagLen+aeadAuthTagLen+srtcpIndexSize)], actualDecrypted, "DecryptRTP failed to decrypt in place")
 
-		// Copy packet, asserts that everything was done in place
-		encryptInput := append([]byte{}, testCase.decrypted...)
+				assert.Equal(pkt.decrypted, actualDecrypted, "RTCP failed to decrypt")
 
-		encryptContext.SetIndex(testCase.ssrc, testCase.index)
-		actualEncrypted, err := encryptContext.EncryptRTCP(encryptInput, encryptInput, encryptHeader)
-		switch {
-		case err != nil:
-			t.Error(err)
-		case encryptHeader.Type != rtcp.TypeSenderReport:
-			t.Fatal("EncryptRTCP failed to populate input rtcp.Header")
-		case !bytes.Equal(encryptInput, actualEncrypted[:len(actualEncrypted)-(authTagLen+srtcpIndexSize)]):
-			t.Fatal("EncryptRTCP failed to encrypt in place")
-		}
+				// Destination buffer should have capacity to store the resutl.
+				// Otherwise, the buffer may be realloc-ed and the actual result will be written to the other address.
+				encryptInput := make([]byte, 0, len(pkt.encrypted))
+				// Copy packet, asserts that everything was done in place
+				encryptInput = append(encryptInput, pkt.decrypted...)
 
-		assert.Equal(actualEncrypted, testCase.encrypted, "RTCP failed to encrypt")
+				encryptContext.SetIndex(pkt.ssrc, pkt.index)
+				actualEncrypted, err := encryptContext.EncryptRTCP(encryptInput, encryptInput, encryptHeader)
+				switch {
+				case err != nil:
+					t.Error(err)
+				case encryptHeader.Type != pkt.pktType:
+					t.Fatalf("EncryptRTCP failed to populate input rtcp.Header, expected: %d, got %d", pkt.pktType, encryptHeader.Type)
+				}
+				assert.Equal(actualEncrypted[:len(actualEncrypted)-(authTagLen+aeadAuthTagLen+srtcpIndexSize)], encryptInput, "EncryptRTCP failed to encrypt in place")
+
+				assert.Equal(pkt.encrypted, actualEncrypted, "RTCP failed to encrypt")
+			}
+		})
 	}
 }
 
 // Assert that passing a dst buffer that is too short doesn't result in a failure
 func TestRTCPLifecyclePartialAllocation(t *testing.T) {
-	assert := assert.New(t)
+	for caseName, testCase := range rtcpTestCases() {
+		testCase := testCase
+		t.Run(caseName, func(t *testing.T) {
+			if testCase.algo == ProtectionProfileAeadAes128Gcm {
+				t.Skip("FIXME: DecryptRTCP(nil, input, nil) for ProtectionProfileAeadAes128Gcm changes input data")
+			}
+			assert := assert.New(t)
 
-	encryptHeader := &rtcp.Header{}
-	encryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo)
-	if err != nil {
-		t.Errorf("CreateContext failed: %v", err)
-	}
+			encryptHeader := &rtcp.Header{}
+			encryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo)
+			if err != nil {
+				t.Errorf("CreateContext failed: %v", err)
+			}
 
-	decryptHeader := &rtcp.Header{}
-	decryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo)
-	if err != nil {
-		t.Errorf("CreateContext failed: %v", err)
-	}
+			decryptHeader := &rtcp.Header{}
+			decryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo)
+			if err != nil {
+				t.Errorf("CreateContext failed: %v", err)
+			}
 
-	for _, testCase := range rtcpTestCases() {
-		// Copy packet, asserts that partial buffers can be used
-		decryptDst := make([]byte, len(testCase.decrypted)*2)
+			for _, pkt := range testCase.packets {
+				// Copy packet, asserts that partial buffers can be used
+				decryptDst := make([]byte, len(pkt.decrypted)*2)
 
-		actualDecrypted, err := decryptContext.DecryptRTCP(decryptDst, testCase.encrypted, decryptHeader)
-		if err != nil {
-			t.Error(err)
-		} else if decryptHeader.Type != rtcp.TypeSenderReport {
-			t.Fatal("DecryptRTCP failed to populate input rtcp.Header")
-		}
-		assert.Equal(actualDecrypted, testCase.decrypted, "RTCP failed to decrypt")
+				actualDecrypted, err := decryptContext.DecryptRTCP(decryptDst, pkt.encrypted, decryptHeader)
+				if err != nil {
+					t.Error(err)
+				} else if decryptHeader.Type != pkt.pktType {
+					t.Fatalf("DecryptRTCP failed to populate input rtcp.Header, expected: %d, got %d", pkt.pktType, decryptHeader.Type)
+				}
+				assert.Equal(pkt.decrypted, actualDecrypted, "RTCP failed to decrypt")
 
-		// Copy packet, asserts that partial buffers can be used
-		encryptDst := make([]byte, len(testCase.encrypted)/2)
+				// Copy packet, asserts that partial buffers can be used
+				encryptDst := make([]byte, len(pkt.encrypted)/2)
 
-		encryptContext.SetIndex(testCase.ssrc, testCase.index)
-		actualEncrypted, err := encryptContext.EncryptRTCP(encryptDst, testCase.decrypted, encryptHeader)
-		if err != nil {
-			t.Error(err)
-		} else if encryptHeader.Type != rtcp.TypeSenderReport {
-			t.Fatal("EncryptRTCP failed to populate input rtcp.Header")
-		}
-		assert.Equal(actualEncrypted, testCase.encrypted, "RTCP failed to encrypt")
+				encryptContext.SetIndex(pkt.ssrc, pkt.index)
+				actualEncrypted, err := encryptContext.EncryptRTCP(encryptDst, pkt.decrypted, encryptHeader)
+				if err != nil {
+					t.Error(err)
+				} else if encryptHeader.Type != pkt.pktType {
+					t.Fatalf("EncryptRTCP failed to populate input rtcp.Header, expected: %d, got %d", pkt.pktType, encryptHeader.Type)
+				}
+				assert.Equal(pkt.encrypted, actualEncrypted, "RTCP failed to encrypt")
+			}
+		})
 	}
 }
 
 func TestRTCPInvalidAuthTag(t *testing.T) {
-	assert := assert.New(t)
-	authTagLen, err := ProtectionProfileAes128CmHmacSha1_80.authTagLen()
-	assert.NoError(err)
+	for caseName, testCase := range rtcpTestCases() {
+		testCase := testCase
+		t.Run(caseName, func(t *testing.T) {
+			assert := assert.New(t)
+			authTagLen, err := testCase.algo.authTagLen()
+			assert.NoError(err)
 
-	decryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo)
-	if err != nil {
-		t.Errorf("CreateContext failed: %v", err)
-	}
+			aeadAuthTagLen, err := testCase.algo.aeadAuthTagLen()
+			assert.NoError(err)
 
-	rtcpPacket := append([]byte{}, rtcpTestCases()[0].encrypted...)
-	decryptResult, err := decryptContext.DecryptRTCP(nil, rtcpPacket, nil)
-	if err != nil {
-		t.Error(err)
-	}
-	assert.Equal(decryptResult, rtcpTestCases()[0].decrypted, "RTCP failed to decrypt")
+			decryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo)
+			if err != nil {
+				t.Errorf("CreateContext failed: %v", err)
+			}
 
-	// Zero out auth tag
-	copy(rtcpPacket[len(rtcpPacket)-authTagLen:], make([]byte, authTagLen))
+			for _, pkt := range testCase.packets {
+				rtcpPacket := append([]byte{}, pkt.encrypted...)
+				decryptResult, err := decryptContext.DecryptRTCP(nil, rtcpPacket, nil)
+				if err != nil {
+					t.Error(err)
+				}
+				assert.Equal(pkt.decrypted, decryptResult, "RTCP failed to decrypt")
 
-	if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket, nil); err == nil {
-		t.Errorf("Was able to decrypt RTCP packet with invalid Auth Tag")
+				// Zero out auth tag
+				if authTagLen > 0 {
+					copy(rtcpPacket[len(rtcpPacket)-authTagLen:], make([]byte, authTagLen))
+				}
+				if aeadAuthTagLen > 0 {
+					authTagPos := len(rtcpPacket) - authTagLen - srtcpIndexSize - aeadAuthTagLen
+					copy(rtcpPacket[authTagPos:authTagPos+aeadAuthTagLen], make([]byte, aeadAuthTagLen))
+				}
+
+				if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket, nil); err == nil {
+					t.Errorf("Was able to decrypt RTCP packet with invalid Auth Tag")
+				}
+			}
+		})
 	}
 }
 
 func TestRTCPReplayDetectorSeparation(t *testing.T) {
-	assert := assert.New(t)
-	decryptContext, err := CreateContext(
-		rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo,
-		SRTCPReplayProtection(10),
-	)
-	if err != nil {
-		t.Errorf("CreateContext failed: %v", err)
-	}
+	for caseName, testCase := range rtcpTestCasesSingle() {
+		testCase := testCase
+		t.Run(caseName, func(t *testing.T) {
+			assert := assert.New(t)
+			decryptContext, err := CreateContext(
+				testCase.masterKey, testCase.masterSalt, testCase.algo,
+				SRTCPReplayProtection(10),
+			)
+			if err != nil {
+				t.Errorf("CreateContext failed: %v", err)
+			}
 
-	rtcpPacket1 := append([]byte{}, rtcpTestCases()[0].encrypted...)
-	decryptResult1, err := decryptContext.DecryptRTCP(nil, rtcpPacket1, nil)
-	if err != nil {
-		t.Error(err)
-	}
-	assert.Equal(decryptResult1, rtcpTestCases()[0].decrypted, "RTCP failed to decrypt")
+			for _, pkt := range testCase.packets {
+				rtcpPacket := append([]byte{}, pkt.encrypted...)
+				decryptResult, errDec := decryptContext.DecryptRTCP(nil, rtcpPacket, nil)
+				if errDec != nil {
+					t.Error(errDec)
+				}
+				assert.Equal(pkt.decrypted, decryptResult, "RTCP failed to decrypt")
+			}
 
-	rtcpPacket2 := append([]byte{}, rtcpTestCases()[1].encrypted...)
-	decryptResult2, err := decryptContext.DecryptRTCP(nil, rtcpPacket2, nil)
-	if err != nil {
-		t.Error(err)
-	}
-	assert.Equal(decryptResult2, rtcpTestCases()[1].decrypted, "RTCP failed to decrypt")
-
-	if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket1, nil); !errors.Is(err, errDuplicated) {
-		t.Errorf("Was able to decrypt duplicated RTCP packet")
-	}
-	if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket2, nil); !errors.Is(err, errDuplicated) {
-		t.Errorf("Was able to decrypt duplicated RTCP packet")
+			for i, pkt := range testCase.packets {
+				rtcpPacket := append([]byte{}, pkt.encrypted...)
+				if _, err = decryptContext.DecryptRTCP(nil, rtcpPacket, nil); !errors.Is(err, errDuplicated) {
+					t.Error("Was able to decrypt duplicated RTCP packet", i)
+				}
+			}
+		})
 	}
 }
 
@@ -249,37 +419,54 @@ func getRTCPIndex(encrypted []byte, authTagLen int) uint32 {
 }
 
 func TestEncryptRTCPSeparation(t *testing.T) {
-	assert := assert.New(t)
-	encryptContext, err := CreateContext(rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo)
-	assert.NoError(err)
+	for caseName, testCase := range rtcpTestCasesSingle() {
+		testCase := testCase
+		t.Run(caseName, func(t *testing.T) {
+			assert := assert.New(t)
+			encryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo)
+			assert.NoError(err)
 
-	authTagLen, err := ProtectionProfileAes128CmHmacSha1_80.authTagLen()
-	assert.NoError(err)
+			authTagLen, err := testCase.algo.authTagLen()
+			assert.NoError(err)
 
-	decryptContext, err := CreateContext(
-		rtcpTestMasterKey(), rtcpTestMasterSalt(), cipherContextAlgo,
-		SRTCPReplayProtection(10),
-	)
-	assert.NoError(err)
+			decryptContext, err := CreateContext(
+				testCase.masterKey, testCase.masterSalt, testCase.algo,
+				SRTCPReplayProtection(10),
+			)
+			assert.NoError(err)
 
-	encryptHeader := &rtcp.Header{}
+			encryptHeader := &rtcp.Header{}
 
-	inputs := [][]byte{rtcpTestCases()[0].decrypted, rtcpTestCases()[1].decrypted, rtcpTestCases()[0].decrypted, rtcpTestCases()[1].decrypted}
-	encryptedRCTPs := make([][]byte, len(inputs))
+			inputs := [][]byte{}
+			expectedIndexes := []uint32{}
+			pktCnt := map[uint32]uint32{}
+			for _, pkt := range testCase.packets {
+				inputs = append(inputs, pkt.decrypted)
+				pktCnt[pkt.ssrc]++
+				expectedIndexes = append(expectedIndexes, pktCnt[pkt.ssrc])
+			}
+			for _, pkt := range testCase.packets {
+				inputs = append(inputs, pkt.decrypted)
+				pktCnt[pkt.ssrc]++
+				expectedIndexes = append(expectedIndexes, pktCnt[pkt.ssrc])
+			}
+			encryptedRCTPs := make([][]byte, len(inputs))
 
-	for i, input := range inputs {
-		encrypted, err := encryptContext.EncryptRTCP(nil, input, encryptHeader)
-		assert.NoError(err)
-		encryptedRCTPs[i] = encrypted
-	}
+			for i, input := range inputs {
+				encrypted, err := encryptContext.EncryptRTCP(nil, input, encryptHeader)
+				assert.NoError(err)
+				encryptedRCTPs[i] = encrypted
+			}
 
-	for i, expectedIndex := range []uint32{1, 1, 2, 2} {
-		assert.Equal(expectedIndex, getRTCPIndex(encryptedRCTPs[i], authTagLen), "RTCP index does not match")
-	}
+			for i, expectedIndex := range expectedIndexes {
+				assert.Equal(expectedIndex, getRTCPIndex(encryptedRCTPs[i], authTagLen), "RTCP index does not match")
+			}
 
-	for i, output := range encryptedRCTPs {
-		decrypted, err := decryptContext.DecryptRTCP(nil, output, encryptHeader)
-		assert.NoError(err)
-		assert.Equal(inputs[i], decrypted)
+			for i, output := range encryptedRCTPs {
+				decrypted, err := decryptContext.DecryptRTCP(nil, output, encryptHeader)
+				assert.NoError(err)
+				assert.Equal(decrypted, inputs[i])
+			}
+		})
 	}
 }

--- a/srtcp_test.go
+++ b/srtcp_test.go
@@ -190,9 +190,6 @@ func TestRTCPLifecycle(t *testing.T) {
 			for caseName, testCase := range rtcpTestCases() {
 				testCase := testCase
 				t.Run(caseName, func(t *testing.T) {
-					if testCase.algo == ProtectionProfileAeadAes128Gcm {
-						t.Skip("FIXME: DecryptRTCP(nil, input, nil) for ProtectionProfileAeadAes128Gcm changes input data")
-					}
 					assert := assert.New(t)
 					encryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo, option...)
 					if err != nil {
@@ -228,9 +225,6 @@ func TestRTCPLifecycleInPlace(t *testing.T) {
 	for caseName, testCase := range rtcpTestCases() {
 		testCase := testCase
 		t.Run(caseName, func(t *testing.T) {
-			if testCase.algo == ProtectionProfileAeadAes128Gcm {
-				t.Skip("ProtectionProfileAeadAes128Gcm implementation currently doesn't support in-place encrypt/decrypt")
-			}
 			assert := assert.New(t)
 			authTagLen, err := testCase.algo.authTagLen()
 			assert.NoError(err)

--- a/srtp_cipher.go
+++ b/srtp_cipher.go
@@ -6,6 +6,7 @@ import "github.com/pion/rtp"
 // of the SRTP Specific ciphers
 type srtpCipher interface {
 	authTagLen() int
+	aeadAuthTagLen() int
 	getRTCPIndex([]byte) uint32
 
 	encryptRTP([]byte, *rtp.Header, []byte, uint32) ([]byte, error)

--- a/srtp_cipher.go
+++ b/srtp_cipher.go
@@ -5,7 +5,11 @@ import "github.com/pion/rtp"
 // cipher represents a implementation of one
 // of the SRTP Specific ciphers
 type srtpCipher interface {
+	// authTagLen returns auth key length of the cipher.
+	// See the note below.
 	authTagLen() int
+	// aeadAuthTagLen returns AEAD auth key length of the cipher.
+	// See the note below.
 	aeadAuthTagLen() int
 	getRTCPIndex([]byte) uint32
 
@@ -15,3 +19,28 @@ type srtpCipher interface {
 	decryptRTP([]byte, []byte, *rtp.Header, uint32) ([]byte, error)
 	decryptRTCP([]byte, []byte, uint32, uint32) ([]byte, error)
 }
+
+/*
+NOTE: Auth tag and AEAD auth tag are placed at the different position in SRTCP
+
+In non-AEAD cipher, the authentication tag is placed *after* the ESRTCP word
+(Encrypted-flag and SRTCP index).
+
+> AES_128_CM_HMAC_SHA1_80
+> | RTCP Header | Encrypted payload |E| SRTCP Index | Auth tag |
+>                                   ^               |----------|
+>                                   |                ^
+>                                   |                authTagLen=10
+>                                   aeadAuthTagLen=0
+
+In AEAD cipher, the AEAD authentication tag is embedded in the ciphertext.
+It is *before* the ESRTCP word (Encrypted-flag and SRTCP index).
+
+> AEAD_AES_128_GCM
+> | RTCP Header | Encrypted payload | AEAD auth tag |E| SRTCP Index |
+>                                   |---------------|               ^
+>                                    ^                              authTagLen=0
+>                                    aeadAuthTagLen=16
+
+See https://tools.ietf.org/html/rfc7714 for the full specifications.
+*/

--- a/srtp_cipher_aead_aes_gcm.go
+++ b/srtp_cipher_aead_aes_gcm.go
@@ -61,6 +61,10 @@ func newSrtpCipherAeadAesGcm(masterKey, masterSalt []byte) (*srtpCipherAeadAesGc
 }
 
 func (s *srtpCipherAeadAesGcm) authTagLen() int {
+	return 0
+}
+
+func (s *srtpCipherAeadAesGcm) aeadAuthTagLen() int {
 	return 16
 }
 

--- a/srtp_cipher_aead_aes_gcm.go
+++ b/srtp_cipher_aead_aes_gcm.go
@@ -69,54 +69,76 @@ func (s *srtpCipherAeadAesGcm) aeadAuthTagLen() int {
 }
 
 func (s *srtpCipherAeadAesGcm) encryptRTP(dst []byte, header *rtp.Header, payload []byte, roc uint32) (ciphertext []byte, err error) {
+	// Grow the given buffer to fit the output.
+	dst = growBufferSize(dst, header.MarshalSize()+len(payload)+s.aeadAuthTagLen())
+
 	hdr, err := header.Marshal()
 	if err != nil {
 		return nil, err
 	}
 
 	iv := s.rtpInitializationVector(header, roc)
-	out := s.srtpCipher.Seal(nil, iv, payload, hdr)
-	return append(hdr, out...), nil
+	nHdr := len(hdr)
+	s.srtpCipher.Seal(dst[nHdr:nHdr], iv, payload, hdr)
+	copy(dst[:nHdr], hdr)
+	return dst, nil
 }
 
 func (s *srtpCipherAeadAesGcm) decryptRTP(dst, ciphertext []byte, header *rtp.Header, roc uint32) ([]byte, error) {
+	// Grow the given buffer to fit the output.
+	nDst := len(ciphertext) - s.aeadAuthTagLen()
+	if nDst < 0 {
+		// Size of ciphertext is shorter than AEAD auth tag len.
+		return nil, errFailedToVerifyAuthTag
+	}
+	dst = growBufferSize(dst, nDst)
+
 	iv := s.rtpInitializationVector(header, roc)
 
-	out, err := s.srtpCipher.Open(nil, iv, ciphertext[header.PayloadOffset:], ciphertext[:header.PayloadOffset])
-	if err != nil {
+	if _, err := s.srtpCipher.Open(
+		dst[header.PayloadOffset:header.PayloadOffset], iv, ciphertext[header.PayloadOffset:], ciphertext[:header.PayloadOffset],
+	); err != nil {
 		return nil, err
 	}
 
-	out = append(make([]byte, header.PayloadOffset), out...)
-	copy(out, ciphertext[:header.PayloadOffset])
-
-	return out, nil
+	copy(dst[:header.PayloadOffset], ciphertext[:header.PayloadOffset])
+	return dst, nil
 }
 
 func (s *srtpCipherAeadAesGcm) encryptRTCP(dst, decrypted []byte, srtcpIndex uint32, ssrc uint32) ([]byte, error) {
+	aadPos := len(decrypted) + s.aeadAuthTagLen()
+	// Grow the given buffer to fit the output.
+	dst = growBufferSize(dst, aadPos+srtcpIndexSize)
+
 	iv := s.rtcpInitializationVector(srtcpIndex, ssrc)
 	aad := s.rtcpAdditionalAuthenticatedData(decrypted, srtcpIndex)
 
-	out := s.srtcpCipher.Seal(nil, iv, decrypted[8:], aad)
+	s.srtcpCipher.Seal(dst[8:8], iv, decrypted[8:], aad)
 
-	out = append(make([]byte, 8), out...)
-	copy(out, decrypted[:8])
-	out = append(out, aad[8:]...)
-
-	return out, nil
+	copy(dst[:8], decrypted[:8])
+	copy(dst[aadPos:aadPos+4], aad[8:12])
+	return dst, nil
 }
 
-func (s *srtpCipherAeadAesGcm) decryptRTCP(out, encrypted []byte, srtcpIndex, ssrc uint32) ([]byte, error) {
+func (s *srtpCipherAeadAesGcm) decryptRTCP(dst, encrypted []byte, srtcpIndex, ssrc uint32) ([]byte, error) {
+	aadPos := len(encrypted) - srtcpIndexSize
+	// Grow the given buffer to fit the output.
+	nDst := aadPos - s.aeadAuthTagLen()
+	if nDst < 0 {
+		// Size of ciphertext is shorter than AEAD auth tag len.
+		return nil, errFailedToVerifyAuthTag
+	}
+	dst = growBufferSize(dst, nDst)
+
 	iv := s.rtcpInitializationVector(srtcpIndex, ssrc)
 	aad := s.rtcpAdditionalAuthenticatedData(encrypted, srtcpIndex)
 
-	decrypted, err := s.srtcpCipher.Open(nil, iv, encrypted[8:len(encrypted)-srtcpIndexSize], aad)
-	if err != nil {
+	if _, err := s.srtcpCipher.Open(dst[8:8], iv, encrypted[8:aadPos], aad); err != nil {
 		return nil, err
 	}
 
-	decrypted = append(encrypted[:8], decrypted...)
-	return decrypted, nil
+	copy(dst[:8], encrypted[:8])
+	return dst, nil
 }
 
 // The 12-octet IV used by AES-GCM SRTP is formed by first concatenating

--- a/srtp_cipher_aes_cm_hmac_sha1.go
+++ b/srtp_cipher_aes_cm_hmac_sha1.go
@@ -68,6 +68,10 @@ func (s *srtpCipherAesCmHmacSha1) authTagLen() int {
 	return 10
 }
 
+func (s *srtpCipherAesCmHmacSha1) aeadAuthTagLen() int {
+	return 0
+}
+
 func (s *srtpCipherAesCmHmacSha1) encryptRTP(dst []byte, header *rtp.Header, payload []byte, roc uint32) (ciphertext []byte, err error) {
 	// Grow the given buffer to fit the output.
 	dst = growBufferSize(dst, header.MarshalSize()+len(payload)+s.authTagLen())


### PR DESCRIPTION
- Fix AEAD auth tag handling
- Add test cases for AEAD_AES_GCM

See https://tools.ietf.org/html/rfc7714#section-16.1.2 about the auth tag location in AEAD_AES_GCM mode.