### PR TITLE
Fix RolloverCount calculation error

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,6 +7,7 @@ Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
 chenkaiC4 <chenkaic4@gmail.com>
 Chris Hiszpanski <chris@hiszpanski.name>
+cszdlt <cszdlt@qq.com>
 Hugo Arregui <hugo.arregui@gmail.com>
 Jerko Steiner <jerko.steiner@gmail.com>
 Juliusz Chroboczek <jch@irif.fr>


### PR DESCRIPTION
#### Description
Fix unorder interval exceeds ```maxROCDisorder``` causing RolloverCount error.

When there is a serious disorder in the network (the disorder segment is greater than ```maxROCDisorder```), the nextRolloverCount will be calculated incorrectly.Will cause srtp decryption to fail.
This PR fixed this problem.

Imitate ```libsrtp/crypto/replay/rdbx.c: srtp_index_guess```