### PR TITLE
Adding link to source of constants

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,6 +3,7 @@
 #
 # This file is auto generated, using git to list all individuals contributors.
 # see `.github/generate-authors.sh` for the scripting
+adamroach <adam@nostrum.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
 chenkaiC4 <chenkaic4@gmail.com>

--- a/protection_profile.go
+++ b/protection_profile.go
@@ -6,6 +6,7 @@ import "fmt"
 type ProtectionProfile uint16
 
 // Supported protection profiles
+// See https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml
 const (
 	ProtectionProfileAes128CmHmacSha1_80 ProtectionProfile = 0x0001
 	ProtectionProfileAeadAes128Gcm       ProtectionProfile = 0x0007


### PR DESCRIPTION
When initially encountering this file, the choice of 0x0001 and 0x0007
for protection profiles is confusing. This just adds a one-line comment
that lets developers know where they come from.