### PR TITLE
Update Context Documentation re: Concurrency

### DIFF
--- a/context.go
+++ b/context.go
@@ -41,6 +41,9 @@ type srtcpSSRCState struct {
 // Context represents a SRTP cryptographic context.
 // Context can only be used for one-way operations.
 // it must either used ONLY for encryption or ONLY for decryption.
+// Note that Context does not provide any concurrency protection:
+// access to a Context from multiple goroutines requires external
+// synchronization.
 type Context struct {
 	cipher srtpCipher
 


### PR DESCRIPTION
Adding text about the threading properties
of Context, to help users avoid race conditions.