### PR TITLE
Remove IV allocation

### DIFF
--- a/key_derivation.go
+++ b/key_derivation.go
@@ -48,8 +48,8 @@ func aesCmKeyDerivation(label byte, masterKey, masterSalt []byte, indexOverKdr i
 // -       passing through 65,535
 // i = 2^16 * ROC + SEQ
 // IV = (salt*2 ^ 16) | (ssrc*2 ^ 64) | (i*2 ^ 16)
-func generateCounter(sequenceNumber uint16, rolloverCounter uint32, ssrc uint32, sessionSalt []byte) []byte {
-	counter := make([]byte, 16)
+func generateCounter(sequenceNumber uint16, rolloverCounter uint32, ssrc uint32, sessionSalt []byte) [16]byte {
+	var counter [16]byte
 
 	binary.BigEndian.PutUint32(counter[4:], ssrc)
 	binary.BigEndian.PutUint32(counter[8:], rolloverCounter)

--- a/srtp_cipher_aes_cm_hmac_sha1.go
+++ b/srtp_cipher_aes_cm_hmac_sha1.go
@@ -84,7 +84,7 @@ func (s *srtpCipherAesCmHmacSha1) encryptRTP(dst []byte, header *rtp.Header, pay
 
 	// Encrypt the payload
 	counter := generateCounter(header.SequenceNumber, roc, header.SSRC, s.srtpSessionSalt)
-	stream := cipher.NewCTR(s.srtpBlock, counter)
+	stream := cipher.NewCTR(s.srtpBlock, counter[:])
 	stream.XORKeyStream(dst[n:], payload)
 	n += len(payload)
 
@@ -122,7 +122,7 @@ func (s *srtpCipherAesCmHmacSha1) decryptRTP(dst, ciphertext []byte, header *rtp
 
 	// Decrypt the ciphertext for the payload.
 	counter := generateCounter(header.SequenceNumber, roc, header.SSRC, s.srtpSessionSalt)
-	stream := cipher.NewCTR(s.srtpBlock, counter)
+	stream := cipher.NewCTR(s.srtpBlock, counter[:])
 	stream.XORKeyStream(dst[headerLen:], ciphertext[headerLen:])
 	return dst, nil
 }
@@ -131,7 +131,8 @@ func (s *srtpCipherAesCmHmacSha1) encryptRTCP(dst, decrypted []byte, srtcpIndex 
 	dst = allocateIfMismatch(dst, decrypted)
 
 	// Encrypt everything after header
-	stream := cipher.NewCTR(s.srtcpBlock, generateCounter(uint16(srtcpIndex&0xffff), srtcpIndex>>16, ssrc, s.srtcpSessionSalt))
+	counter := generateCounter(uint16(srtcpIndex&0xffff), srtcpIndex>>16, ssrc, s.srtcpSessionSalt)
+	stream := cipher.NewCTR(s.srtcpBlock, counter[:])
 	stream.XORKeyStream(dst[8:], dst[8:])
 
 	// Add SRTCP Index and set Encryption bit
@@ -160,7 +161,8 @@ func (s *srtpCipherAesCmHmacSha1) decryptRTCP(out, encrypted []byte, index, ssrc
 		return nil, errFailedToVerifyAuthTag
 	}
 
-	stream := cipher.NewCTR(s.srtcpBlock, generateCounter(uint16(index&0xffff), index>>16, ssrc, s.srtcpSessionSalt))
+	counter := generateCounter(uint16(index&0xffff), index>>16, ssrc, s.srtcpSessionSalt)
+	stream := cipher.NewCTR(s.srtcpBlock, counter[:])
 	stream.XORKeyStream(out[8:], out[8:])
 
 	return out, nil

--- a/srtp_test.go
+++ b/srtp_test.go
@@ -49,7 +49,7 @@ func TestValidPacketCounter(t *testing.T) {
 	s := &srtpSSRCState{ssrc: 4160032510}
 	expectedCounter := []byte{0xcf, 0x90, 0x1e, 0xa5, 0xda, 0xd3, 0x2c, 0x15, 0x00, 0xa2, 0x24, 0xae, 0xae, 0xaf, 0x00, 0x00}
 	counter := generateCounter(32846, uint32(s.index>>16), s.ssrc, srtpSessionSalt)
-	if !bytes.Equal(counter, expectedCounter) {
+	if !bytes.Equal(counter[:], expectedCounter) {
 		t.Errorf("Session Key % 02x does not match expected % 02x", counter, expectedCounter)
 	}
 }


### PR DESCRIPTION
We use an array of 16 bytes instead of a slice,
which prevents it from being escaped to heap.

```
go tool compile  -m key_derivation.go errors.go | grep key_derivation.go:52
key_derivation.go:52:17: make([]byte, 16) escapes to heap
```

This does not happen now.

Benchmarks don't show much difference because the order
is in microseconds. But from the flame graphs, I can confirm that the allocation
is indeed gone.

```
name        old time/op    new time/op    delta
WriteRTP-8    1.55µs ± 3%    1.52µs ± 3%   ~     (p=0.068 n=10+9)

name        old alloc/op   new alloc/op   delta
WriteRTP-8      804B ± 0%      804B ± 0%   ~     (all equal)

name        old allocs/op  new allocs/op  delta
WriteRTP-8      8.00 ± 0%      8.00 ± 0%   ~     (all equal)
```

/cc @streamer45