### PR TITLE
Add support for AES128_CM_HMAC_SHA1_32

### DIFF
--- a/context.go
+++ b/context.go
@@ -86,9 +86,9 @@ func CreateContext(masterKey, masterSalt []byte, profile ProtectionProfile, opts
 
 	switch profile {
 	case ProtectionProfileAeadAes128Gcm:
-		c.cipher, err = newSrtpCipherAeadAesGcm(masterKey, masterSalt)
-	case ProtectionProfileAes128CmHmacSha1_80:
-		c.cipher, err = newSrtpCipherAesCmHmacSha1(masterKey, masterSalt)
+		c.cipher, err = newSrtpCipherAeadAesGcm(profile, masterKey, masterSalt)
+	case ProtectionProfileAes128CmHmacSha1_32, ProtectionProfileAes128CmHmacSha1_80:
+		c.cipher, err = newSrtpCipherAesCmHmacSha1(profile, masterKey, masterSalt)
 	default:
 		return nil, fmt.Errorf("%w: %#v", errNoSuchSRTPProfile, profile)
 	}

--- a/protection_profile.go
+++ b/protection_profile.go
@@ -9,14 +9,13 @@ type ProtectionProfile uint16
 // See https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml
 const (
 	ProtectionProfileAes128CmHmacSha1_80 ProtectionProfile = 0x0001
+	ProtectionProfileAes128CmHmacSha1_32 ProtectionProfile = 0x0002
 	ProtectionProfileAeadAes128Gcm       ProtectionProfile = 0x0007
 )
 
 func (p ProtectionProfile) keyLen() (int, error) {
 	switch p {
-	case ProtectionProfileAes128CmHmacSha1_80:
-		fallthrough
-	case ProtectionProfileAeadAes128Gcm:
+	case ProtectionProfileAes128CmHmacSha1_32, ProtectionProfileAes128CmHmacSha1_80, ProtectionProfileAeadAes128Gcm:
 		return 16, nil
 	default:
 		return 0, fmt.Errorf("%w: %#v", errNoSuchSRTPProfile, p)
@@ -25,7 +24,7 @@ func (p ProtectionProfile) keyLen() (int, error) {
 
 func (p ProtectionProfile) saltLen() (int, error) {
 	switch p {
-	case ProtectionProfileAes128CmHmacSha1_80:
+	case ProtectionProfileAes128CmHmacSha1_32, ProtectionProfileAes128CmHmacSha1_80:
 		return 14, nil
 	case ProtectionProfileAeadAes128Gcm:
 		return 12, nil
@@ -34,12 +33,25 @@ func (p ProtectionProfile) saltLen() (int, error) {
 	}
 }
 
-func (p ProtectionProfile) authTagLen() (int, error) {
+func (p ProtectionProfile) rtpAuthTagLen() (int, error) {
 	switch p {
 	case ProtectionProfileAes128CmHmacSha1_80:
-		return (&srtpCipherAesCmHmacSha1{}).authTagLen(), nil
+		return 10, nil
+	case ProtectionProfileAes128CmHmacSha1_32:
+		return 4, nil
 	case ProtectionProfileAeadAes128Gcm:
-		return (&srtpCipherAeadAesGcm{}).authTagLen(), nil
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("%w: %#v", errNoSuchSRTPProfile, p)
+	}
+}
+
+func (p ProtectionProfile) rtcpAuthTagLen() (int, error) {
+	switch p {
+	case ProtectionProfileAes128CmHmacSha1_32, ProtectionProfileAes128CmHmacSha1_80:
+		return 10, nil
+	case ProtectionProfileAeadAes128Gcm:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%w: %#v", errNoSuchSRTPProfile, p)
 	}
@@ -47,10 +59,10 @@ func (p ProtectionProfile) authTagLen() (int, error) {
 
 func (p ProtectionProfile) aeadAuthTagLen() (int, error) {
 	switch p {
-	case ProtectionProfileAes128CmHmacSha1_80:
-		return (&srtpCipherAesCmHmacSha1{}).aeadAuthTagLen(), nil
+	case ProtectionProfileAes128CmHmacSha1_32, ProtectionProfileAes128CmHmacSha1_80:
+		return 0, nil
 	case ProtectionProfileAeadAes128Gcm:
-		return (&srtpCipherAeadAesGcm{}).aeadAuthTagLen(), nil
+		return 16, nil
 	default:
 		return 0, fmt.Errorf("%w: %#v", errNoSuchSRTPProfile, p)
 	}
@@ -58,7 +70,7 @@ func (p ProtectionProfile) aeadAuthTagLen() (int, error) {
 
 func (p ProtectionProfile) authKeyLen() (int, error) {
 	switch p {
-	case ProtectionProfileAes128CmHmacSha1_80:
+	case ProtectionProfileAes128CmHmacSha1_32, ProtectionProfileAes128CmHmacSha1_80:
 		return 20, nil
 	case ProtectionProfileAeadAes128Gcm:
 		return 0, nil

--- a/session_srtcp_test.go
+++ b/session_srtcp_test.go
@@ -301,7 +301,7 @@ func TestSessionSRTCPReplayProtection(t *testing.T) {
 }
 
 func getSenderSSRC(t *testing.T, stream *ReadStreamSRTCP) (ssrc uint32, err error) {
-	authTagSize, err := ProtectionProfileAes128CmHmacSha1_80.authTagLen()
+	authTagSize, err := ProtectionProfileAes128CmHmacSha1_80.rtcpAuthTagLen()
 	if err != nil {
 		return 0, err
 	}

--- a/srtcp_test.go
+++ b/srtcp_test.go
@@ -226,7 +226,7 @@ func TestRTCPLifecycleInPlace(t *testing.T) {
 		testCase := testCase
 		t.Run(caseName, func(t *testing.T) {
 			assert := assert.New(t)
-			authTagLen, err := testCase.algo.authTagLen()
+			authTagLen, err := testCase.algo.rtcpAuthTagLen()
 			assert.NoError(err)
 
 			aeadAuthTagLen, err := testCase.algo.aeadAuthTagLen()
@@ -338,7 +338,7 @@ func TestRTCPInvalidAuthTag(t *testing.T) {
 		testCase := testCase
 		t.Run(caseName, func(t *testing.T) {
 			assert := assert.New(t)
-			authTagLen, err := testCase.algo.authTagLen()
+			authTagLen, err := testCase.algo.rtcpAuthTagLen()
 			assert.NoError(err)
 
 			aeadAuthTagLen, err := testCase.algo.aeadAuthTagLen()
@@ -420,7 +420,7 @@ func TestEncryptRTCPSeparation(t *testing.T) {
 			encryptContext, err := CreateContext(testCase.masterKey, testCase.masterSalt, testCase.algo)
 			assert.NoError(err)
 
-			authTagLen, err := testCase.algo.authTagLen()
+			authTagLen, err := testCase.algo.rtcpAuthTagLen()
 			assert.NoError(err)
 
 			decryptContext, err := CreateContext(

--- a/srtp.go
+++ b/srtp.go
@@ -15,10 +15,14 @@ func (c *Context) decryptRTP(dst, ciphertext []byte, header *rtp.Header, headerL
 		}
 	}
 
-	dst = growBufferSize(dst, len(ciphertext)-c.cipher.authTagLen())
+	authTagLen, err := c.cipher.rtpAuthTagLen()
+	if err != nil {
+		return nil, err
+	}
+	dst = growBufferSize(dst, len(ciphertext)-authTagLen)
 	roc, updateROC := s.nextRolloverCount(header.SequenceNumber)
 
-	dst, err := c.cipher.decryptRTP(dst, ciphertext, header, headerLen, roc)
+	dst, err = c.cipher.decryptRTP(dst, ciphertext, header, headerLen, roc)
 	if err != nil {
 		return nil, err
 	}

--- a/srtp_cipher.go
+++ b/srtp_cipher.go
@@ -7,10 +7,11 @@ import "github.com/pion/rtp"
 type srtpCipher interface {
 	// authTagLen returns auth key length of the cipher.
 	// See the note below.
-	authTagLen() int
+	rtpAuthTagLen() (int, error)
+	rtcpAuthTagLen() (int, error)
 	// aeadAuthTagLen returns AEAD auth key length of the cipher.
 	// See the note below.
-	aeadAuthTagLen() int
+	aeadAuthTagLen() (int, error)
 	getRTCPIndex([]byte) uint32
 
 	encryptRTP([]byte, *rtp.Header, []byte, uint32) ([]byte, error)


### PR DESCRIPTION
Adding support for SRTP_AES128_CM_HMAC_SHA1_32 as described in RFC 5764.
This necessitated some light refactoring of how `srtpCipher`s interact
with `ProtectionProfile`: the handling of this profile is identical
to handling for SRTP_AES128_CM_HMAC_SHA1_80, but the parameters are
different. This change assigns a profile to a cipher when it is created,
and all profile parameters are delegated to the profile (rather than the
previous setup, which split the values of profile parameters across the
profile and the cipher). This change also splits `authTagLen` into
`rtpAuthTagLen` and `rtcpAuthTagLen`, since they can have different
values depending on the profile in use.