### PR TITLE
Use MarshalTo in GCM encryptRTP

### DIFF
--- a/srtp_cipher_aead_aes_gcm.go
+++ b/srtp_cipher_aead_aes_gcm.go
@@ -70,15 +70,13 @@ func (s *srtpCipherAeadAesGcm) encryptRTP(dst []byte, header *rtp.Header, payloa
 	}
 	dst = growBufferSize(dst, header.MarshalSize()+len(payload)+authTagLen)
 
-	hdr, err := header.Marshal()
+	n, err := header.MarshalTo(dst)
 	if err != nil {
 		return nil, err
 	}
 
 	iv := s.rtpInitializationVector(header, roc)
-	nHdr := len(hdr)
-	s.srtpCipher.Seal(dst[nHdr:nHdr], iv[:], payload, hdr)
-	copy(dst[:nHdr], hdr)
+	s.srtpCipher.Seal(dst[n:n], iv[:], payload, dst[:n])
 	return dst, nil
 }
 


### PR DESCRIPTION
This PR is based off #191.

No big deal, just an easy optimisation.

```
name            old time/op    new time/op    delta
Write/GCM-8        434ns ± 4%     430ns ± 6%     ~     (p=0.686 n=4+4)
WriteRTP/GCM-8     326ns ± 2%     302ns ± 6%     ~     (p=0.057 n=4+4)

name            old speed      new speed      delta
Write/GCM-8      258MB/s ± 4%   261MB/s ± 6%     ~     (p=0.686 n=4+4)
WriteRTP/GCM-8   344MB/s ± 2%   372MB/s ± 6%     ~     (p=0.057 n=4+4)

name            old alloc/op   new alloc/op   delta
Write/GCM-8         272B ± 0%      256B ± 0%   -5.88%  (p=0.029 n=4+4)
WriteRTP/GCM-8      160B ± 0%      144B ± 0%  -10.00%  (p=0.029 n=4+4)

name            old allocs/op  new allocs/op  delta
Write/GCM-8         4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.029 n=4+4)
WriteRTP/GCM-8      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.029 n=4+4)
```
