### PR TITLE
Add benchmarks for large packets

### DIFF
--- a/srtp_test.go
+++ b/srtp_test.go
@@ -423,13 +423,13 @@ func TestRTPReplayProtection(t *testing.T) {
 	t.Run("GCM", func(t *testing.T) { testRTPReplayProtection(t, profileGCM) })
 }
 
-func benchmarkEncryptRTP(b *testing.B, profile ProtectionProfile) {
+func benchmarkEncryptRTP(b *testing.B, profile ProtectionProfile, size int) {
 	encryptContext, err := buildTestContext(profile)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	pkt := &rtp.Packet{Payload: make([]byte, 100)}
+	pkt := &rtp.Packet{Payload: make([]byte, size)}
 	pktRaw, err := pkt.Marshal()
 	if err != nil {
 		b.Fatal(err)
@@ -447,17 +447,27 @@ func benchmarkEncryptRTP(b *testing.B, profile ProtectionProfile) {
 }
 
 func BenchmarkEncryptRTP(b *testing.B) {
-	b.Run("CTR", func(b *testing.B) { benchmarkEncryptRTP(b, profileCTR) })
-	b.Run("GCM", func(b *testing.B) { benchmarkEncryptRTP(b, profileGCM) })
+	b.Run("CTR-100", func(b *testing.B) {
+		benchmarkEncryptRTP(b, profileCTR, 100)
+	})
+	b.Run("CTR-1000", func(b *testing.B) {
+		benchmarkEncryptRTP(b, profileCTR, 1000)
+	})
+	b.Run("GCM-100", func(b *testing.B) {
+		benchmarkEncryptRTP(b, profileGCM, 100)
+	})
+	b.Run("GCM-1000", func(b *testing.B) {
+		benchmarkEncryptRTP(b, profileGCM, 1000)
+	})
 }
 
-func benchmarkEncryptRTPInPlace(b *testing.B, profile ProtectionProfile) {
+func benchmarkEncryptRTPInPlace(b *testing.B, profile ProtectionProfile, size int) {
 	encryptContext, err := buildTestContext(profile)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	pkt := &rtp.Packet{Payload: make([]byte, 100)}
+	pkt := &rtp.Packet{Payload: make([]byte, size)}
 	pktRaw, err := pkt.Marshal()
 	if err != nil {
 		b.Fatal(err)
@@ -477,8 +487,18 @@ func benchmarkEncryptRTPInPlace(b *testing.B, profile ProtectionProfile) {
 }
 
 func BenchmarkEncryptRTPInPlace(b *testing.B) {
-	b.Run("CTR", func(b *testing.B) { benchmarkEncryptRTPInPlace(b, profileCTR) })
-	b.Run("GCM", func(b *testing.B) { benchmarkEncryptRTPInPlace(b, profileGCM) })
+	b.Run("CTR-100", func(b *testing.B) {
+		benchmarkEncryptRTPInPlace(b, profileCTR, 100)
+	})
+	b.Run("CTR-1000", func(b *testing.B) {
+		benchmarkEncryptRTPInPlace(b, profileCTR, 1000)
+	})
+	b.Run("GCM-100", func(b *testing.B) {
+		benchmarkEncryptRTPInPlace(b, profileGCM, 100)
+	})
+	b.Run("GCM-1000", func(b *testing.B) {
+		benchmarkEncryptRTPInPlace(b, profileGCM, 1000)
+	})
 }
 
 func benchmarkDecryptRTP(b *testing.B, profile ProtectionProfile) {

--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -61,7 +61,7 @@ func TestBufferFactory(t *testing.T) {
 	wg.Wait()
 }
 
-func benchmarkWrite(b *testing.B, profile ProtectionProfile) {
+func benchmarkWrite(b *testing.B, profile ProtectionProfile, size int) {
 	conn := newNoopConn()
 
 	keyLen, err := profile.keyLen()
@@ -98,7 +98,7 @@ func benchmarkWrite(b *testing.B, profile ProtectionProfile) {
 			Version: 2,
 			SSRC:    322,
 		},
-		Payload: make([]byte, 100),
+		Payload: make([]byte, size),
 	}
 
 	packetRaw, err := packet.Marshal()
@@ -125,11 +125,21 @@ func benchmarkWrite(b *testing.B, profile ProtectionProfile) {
 }
 
 func BenchmarkWrite(b *testing.B) {
-	b.Run("CTR", func(b *testing.B) { benchmarkWrite(b, profileCTR) })
-	b.Run("GCM", func(b *testing.B) { benchmarkWrite(b, profileGCM) })
+	b.Run("CTR-100", func(b *testing.B) {
+		benchmarkWrite(b, profileCTR, 100)
+	})
+	b.Run("CTR-1000", func(b *testing.B) {
+		benchmarkWrite(b, profileCTR, 1000)
+	})
+	b.Run("GCM-100", func(b *testing.B) {
+		benchmarkWrite(b, profileGCM, 100)
+	})
+	b.Run("GCM-1000", func(b *testing.B) {
+		benchmarkWrite(b, profileGCM, 1000)
+	})
 }
 
-func benchmarkWriteRTP(b *testing.B, profile ProtectionProfile) {
+func benchmarkWriteRTP(b *testing.B, profile ProtectionProfile, size int) {
 	conn := &noopConn{
 		closed: make(chan struct{}),
 	}
@@ -168,7 +178,7 @@ func benchmarkWriteRTP(b *testing.B, profile ProtectionProfile) {
 		SSRC:    322,
 	}
 
-	payload := make([]byte, 100)
+	payload := make([]byte, size)
 
 	b.SetBytes(int64(header.MarshalSize() + len(payload)))
 	b.ResetTimer()
@@ -189,6 +199,16 @@ func benchmarkWriteRTP(b *testing.B, profile ProtectionProfile) {
 }
 
 func BenchmarkWriteRTP(b *testing.B) {
-	b.Run("CTR", func(b *testing.B) { benchmarkWriteRTP(b, profileCTR) })
-	b.Run("GCM", func(b *testing.B) { benchmarkWriteRTP(b, profileGCM) })
+	b.Run("CTR-100", func(b *testing.B) {
+		benchmarkWriteRTP(b, profileCTR, 100)
+	})
+	b.Run("CTR-1400", func(b *testing.B) {
+		benchmarkWriteRTP(b, profileCTR, 1000)
+	})
+	b.Run("GCM-100", func(b *testing.B) {
+		benchmarkWriteRTP(b, profileGCM, 100)
+	})
+	b.Run("GCM-1000", func(b *testing.B) {
+		benchmarkWriteRTP(b, profileGCM, 1000)
+	})
 }


### PR DESCRIPTION
Add benchmarks for 1000-byte packets in addition to the existing benchmarks for 100-byte packets.  With GCM and hardware crypto, there's basically no longer any measurable overhead due to crypto!

```
BenchmarkEncryptRTP/CTR-100-8    1059247              1046 ns/op         107.04 MB/s
BenchmarkEncryptRTP/CTR-1000-8    241134              5426 ns/op         186.53 MB/s
BenchmarkEncryptRTP/GCM-100-8    3441193               352.9 ns/op       317.33 MB/s
BenchmarkEncryptRTP/GCM-1000-8   1515955               735.7 ns/op      1375.59 MB/s
BenchmarkEncryptRTPInPlace/CTR-100-8              947760              1065 ns/op      105.19 MB/s
BenchmarkEncryptRTPInPlace/CTR-1000-8             261597              4703 ns/op      215.18 MB/s
BenchmarkEncryptRTPInPlace/GCM-100-8             4298205               278.7 ns/op    401.84 MB/s
BenchmarkEncryptRTPInPlace/GCM-1000-8            2497886               491.3 ns/op   2059.87 MB/s
```
