### PR TITLE
Fix typo in test name

### DIFF
--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -202,7 +202,7 @@ func BenchmarkWriteRTP(b *testing.B) {
 	b.Run("CTR-100", func(b *testing.B) {
 		benchmarkWriteRTP(b, profileCTR, 100)
 	})
-	b.Run("CTR-1400", func(b *testing.B) {
+	b.Run("CTR-1000", func(b *testing.B) {
 		benchmarkWriteRTP(b, profileCTR, 1000)
 	})
 	b.Run("GCM-100", func(b *testing.B) {


### PR DESCRIPTION
There was a typo in the name of the test: it's using 1000 byte
packets, not 1400.
