### PR TITLE
Optimise generateCounter (AES-CM-HMAC-SHA1)

### DIFF
--- a/key_derivation.go
+++ b/key_derivation.go
@@ -48,16 +48,19 @@ func aesCmKeyDerivation(label byte, masterKey, masterSalt []byte, indexOverKdr i
 // -       passing through 65,535
 // i = 2^16 * ROC + SEQ
 // IV = (salt*2 ^ 16) | (ssrc*2 ^ 64) | (i*2 ^ 16)
-func generateCounter(sequenceNumber uint16, rolloverCounter uint32, ssrc uint32, sessionSalt []byte) [16]byte {
-	var counter [16]byte
+func generateCounter(sequenceNumber uint16, rolloverCounter uint32, ssrc uint32, sessionSalt []byte) (counter [16]byte) {
+	copy(counter[:], sessionSalt)
 
-	binary.BigEndian.PutUint32(counter[4:], ssrc)
-	binary.BigEndian.PutUint32(counter[8:], rolloverCounter)
-	binary.BigEndian.PutUint32(counter[12:], uint32(sequenceNumber)<<16)
-
-	for i := range sessionSalt {
-		counter[i] ^= sessionSalt[i]
-	}
+	counter[4] ^= byte(ssrc >> 24)
+	counter[5] ^= byte(ssrc >> 16)
+	counter[6] ^= byte(ssrc >> 8)
+	counter[7] ^= byte(ssrc)
+	counter[8] ^= byte(rolloverCounter >> 24)
+	counter[9] ^= byte(rolloverCounter >> 16)
+	counter[10] ^= byte(rolloverCounter >> 8)
+	counter[11] ^= byte(rolloverCounter)
+	counter[12] ^= byte(sequenceNumber >> 8)
+	counter[13] ^= byte(sequenceNumber)
 
 	return counter
 }

--- a/key_derivation_test.go
+++ b/key_derivation_test.go
@@ -46,3 +46,19 @@ func TestIndexOverKDR(t *testing.T) {
 	_, err := aesCmKeyDerivation(labelSRTPAuthenticationTag, []byte{}, []byte{}, 1, 0)
 	assert.Error(t, err)
 }
+
+func BenchmarkGenerateCounter(b *testing.B) {
+	masterKey := []byte{0x0d, 0xcd, 0x21, 0x3e, 0x4c, 0xbc, 0xf2, 0x8f, 0x01, 0x7f, 0x69, 0x94, 0x40, 0x1e, 0x28, 0x89}
+	masterSalt := []byte{0x62, 0x77, 0x60, 0x38, 0xc0, 0x6d, 0xc9, 0x41, 0x9f, 0x6d, 0xd9, 0x43, 0x3e, 0x7c}
+
+	s := &srtpSSRCState{ssrc: 4160032510}
+
+	srtpSessionSalt, err := aesCmKeyDerivation(labelSRTPSalt, masterKey, masterSalt, 0, len(masterSalt))
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		generateCounter(32846, uint32(s.index>>16), s.ssrc, srtpSessionSalt)
+	}
+}


### PR DESCRIPTION
Before
```
goos: darwin
goarch: amd64
pkg: github.com/pion/srtp/v2
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkGenerateCounter
BenchmarkGenerateCounter-12      	97850202	        12.26 ns/op
```

After
```
BenchmarkGenerateCounter
BenchmarkGenerateCounter-12      	175902676	         6.383 ns/op
```

This updates a proposed code change from @kixelated back in 2019.
