### PR TITLE
Optimise xorBytes - huge gains for SRTP AES-CM

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -2,6 +2,7 @@ package srtp
 
 import (
 	"crypto/cipher"
+	"unsafe"
 )
 
 // xorBytes computes the exclusive-or of src1 and src2 and stores it in dst.
@@ -15,7 +16,10 @@ func xorBytes(dst, src1, src2 []byte) int {
 		n = len(dst)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := 0; i < n / 4; i++ {
+		(*(*[]uint32)(unsafe.Pointer(&dst)))[i] = (*(*[]uint32)(unsafe.Pointer(&src1)))[i] ^ (*(*[]uint32)(unsafe.Pointer(&src2)))[i]
+	}
+	for i := (n / 4) * 4; i < n; i++ {
 		dst[i] = src1[i] ^ src2[i]
 	}
 

--- a/key_derivation.go
+++ b/key_derivation.go
@@ -48,16 +48,19 @@ func aesCmKeyDerivation(label byte, masterKey, masterSalt []byte, indexOverKdr i
 // -       passing through 65,535
 // i = 2^16 * ROC + SEQ
 // IV = (salt*2 ^ 16) | (ssrc*2 ^ 64) | (i*2 ^ 16)
-func generateCounter(sequenceNumber uint16, rolloverCounter uint32, ssrc uint32, sessionSalt []byte) [16]byte {
-	var counter [16]byte
+func generateCounter(sequenceNumber uint16, rolloverCounter uint32, ssrc uint32, sessionSalt []byte) (counter [16]byte) {
+	copy(counter[:], sessionSalt)
 
-	binary.BigEndian.PutUint32(counter[4:], ssrc)
-	binary.BigEndian.PutUint32(counter[8:], rolloverCounter)
-	binary.BigEndian.PutUint32(counter[12:], uint32(sequenceNumber)<<16)
-
-	for i := range sessionSalt {
-		counter[i] ^= sessionSalt[i]
-	}
+	counter[4] ^= byte(ssrc >> 24)
+	counter[5] ^= byte(ssrc >> 16)
+	counter[6] ^= byte(ssrc >> 8)
+	counter[7] ^= byte(ssrc)
+	counter[8] ^= byte(rolloverCounter >> 24)
+	counter[9] ^= byte(rolloverCounter >> 16)
+	counter[10] ^= byte(rolloverCounter >> 8)
+	counter[11] ^= byte(rolloverCounter)
+	counter[12] ^= byte(sequenceNumber >> 8)
+	counter[13] ^= byte(sequenceNumber)
 
 	return counter
 }

--- a/key_derivation_test.go
+++ b/key_derivation_test.go
@@ -46,3 +46,19 @@ func TestIndexOverKDR(t *testing.T) {
 	_, err := aesCmKeyDerivation(labelSRTPAuthenticationTag, []byte{}, []byte{}, 1, 0)
 	assert.Error(t, err)
 }
+
+func BenchmarkGenerateCounter(b *testing.B) {
+	masterKey := []byte{0x0d, 0xcd, 0x21, 0x3e, 0x4c, 0xbc, 0xf2, 0x8f, 0x01, 0x7f, 0x69, 0x94, 0x40, 0x1e, 0x28, 0x89}
+	masterSalt := []byte{0x62, 0x77, 0x60, 0x38, 0xc0, 0x6d, 0xc9, 0x41, 0x9f, 0x6d, 0xd9, 0x43, 0x3e, 0x7c}
+
+	s := &srtpSSRCState{ssrc: 4160032510}
+
+	srtpSessionSalt, err := aesCmKeyDerivation(labelSRTPSalt, masterKey, masterSalt, 0, len(masterSalt))
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		generateCounter(32846, uint32(s.index>>16), s.ssrc, srtpSessionSalt)
+	}
+}


### PR DESCRIPTION
```
name                           old time/op    new time/op    delta
EncryptRTP/CTR-100-12             852ns ± 1%     758ns ± 2%  -11.09%  (p=0.000 n=9+10)
EncryptRTP/CTR-1000-12           3.98µs ± 1%    2.96µs ± 2%  -25.69%  (p=0.000 n=10+10)
EncryptRTPInPlace/CTR-100-12      824ns ± 1%     734ns ± 4%  -10.93%  (p=0.000 n=10+9)
EncryptRTPInPlace/CTR-1000-12    3.89µs ± 5%    2.85µs ± 1%  -26.77%  (p=0.000 n=10+10)
DecryptRTP/CTR-12                 518ns ± 1%     515ns ± 1%   -0.70%  (p=0.040 n=9+9)
Write/CTR-100-12                  863ns ± 1%     762ns ± 1%  -11.71%  (p=0.000 n=10+9)
Write/CTR-1000-12                3.91µs ± 2%    2.90µs ± 2%  -25.85%  (p=0.000 n=9+9)
WriteRTP/CTR-100-12               816ns ± 4%     694ns ± 2%  -14.93%  (p=0.000 n=10+10)
WriteRTP/CTR-1400-12             3.95µs ± 3%    2.79µs ± 1%  -29.21%  (p=0.000 n=10+9)

name                           old speed      new speed      delta
EncryptRTP/CTR-100-12           131MB/s ± 1%   148MB/s ± 2%  +12.48%  (p=0.000 n=9+10)
EncryptRTP/CTR-1000-12          254MB/s ± 1%   342MB/s ± 2%  +34.58%  (p=0.000 n=10+10)
EncryptRTPInPlace/CTR-100-12    136MB/s ± 1%   153MB/s ± 3%  +12.29%  (p=0.000 n=10+9)
EncryptRTPInPlace/CTR-1000-12   260MB/s ± 5%   355MB/s ± 1%  +36.51%  (p=0.000 n=10+10)
DecryptRTP/CTR-12              54.0MB/s ± 1%  54.4MB/s ± 1%   +0.70%  (p=0.040 n=9+9)
Write/CTR-100-12                130MB/s ± 1%   147MB/s ± 1%  +13.25%  (p=0.000 n=10+9)
Write/CTR-1000-12               259MB/s ± 2%   349MB/s ± 2%  +34.85%  (p=0.000 n=9+9)
WriteRTP/CTR-100-12             137MB/s ± 4%   161MB/s ± 2%  +17.52%  (p=0.000 n=10+10)
WriteRTP/CTR-1400-12            256MB/s ± 3%   362MB/s ± 1%  +41.22%  (p=0.000 n=10+9)
```