### PR TITLE
Optimise xorBytes - huge gains for SRTP AES-CM

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -2,6 +2,7 @@ package srtp
 
 import (
 	"crypto/cipher"
+	"unsafe"
 )
 
 // xorBytes computes the exclusive-or of src1 and src2 and stores it in dst.
@@ -15,7 +16,10 @@ func xorBytes(dst, src1, src2 []byte) int {
 		n = len(dst)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := 0; i < n/4; i++ {
+		(*(*[]uint32)(unsafe.Pointer(&dst)))[i] = (*(*[]uint32)(unsafe.Pointer(&src1)))[i] ^ (*(*[]uint32)(unsafe.Pointer(&src2)))[i]
+	}
+	for i := (n / 4) * 4; i < n; i++ {
 		dst[i] = src1[i] ^ src2[i]
 	}
 


### PR DESCRIPTION
```
name                           old time/op    new time/op    delta
EncryptRTP/CTR-100-12             852ns ± 1%     758ns ± 2%  -11.09%
EncryptRTP/CTR-1000-12           3.98µs ± 1%    2.96µs ± 2%  -25.69%
EncryptRTPInPlace/CTR-100-12      824ns ± 1%     734ns ± 4%  -10.93%
EncryptRTPInPlace/CTR-1000-12    3.89µs ± 5%    2.85µs ± 1%  -26.77%
DecryptRTP/CTR-12                 518ns ± 1%     515ns ± 1%   -0.70%
Write/CTR-100-12                  863ns ± 1%     762ns ± 1%  -11.71%
Write/CTR-1000-12                3.91µs ± 2%    2.90µs ± 2%  -25.85%
WriteRTP/CTR-100-12               816ns ± 4%     694ns ± 2%  -14.93%
WriteRTP/CTR-1400-12             3.95µs ± 3%    2.79µs ± 1%  -29.21%

name                           old speed      new speed      delta
EncryptRTP/CTR-100-12           131MB/s ± 1%   148MB/s ± 2%  +12.48%
EncryptRTP/CTR-1000-12          254MB/s ± 1%   342MB/s ± 2%  +34.58%
EncryptRTPInPlace/CTR-100-12    136MB/s ± 1%   153MB/s ± 3%  +12.29%
EncryptRTPInPlace/CTR-1000-12   260MB/s ± 5%   355MB/s ± 1%  +36.51%
DecryptRTP/CTR-12              54.0MB/s ± 1%  54.4MB/s ± 1%   +0.70%
Write/CTR-100-12                130MB/s ± 1%   147MB/s ± 1%  +13.25%
Write/CTR-1000-12               259MB/s ± 2%   349MB/s ± 2%  +34.85%
WriteRTP/CTR-100-12             137MB/s ± 4%   161MB/s ± 2%  +17.52%
WriteRTP/CTR-1400-12            256MB/s ± 3%   362MB/s ± 1%  +41.22%
```