### PR TITLE
Fix rollover estimation after SetROC

### DIFF
--- a/context.go
+++ b/context.go
@@ -201,7 +201,8 @@ func (c *Context) ROC(ssrc uint32) (uint32, bool) {
 // SetROC sets SRTP rollover counter value of specified SSRC.
 func (c *Context) SetROC(ssrc uint32, roc uint32) {
 	s := c.getSRTPSSRCState(ssrc)
-	s.index = uint64(roc)<<16 | (s.index & (seqNumMax - 1))
+	s.index = uint64(roc) << 16
+	s.rolloverHasProcessed = false
 }
 
 // Index returns SRTCP index value of specified SSRC.


### PR DESCRIPTION
SRTP context estimated the wrong ROC when the sequence number is overflown during burst packet loss, and SetROC gives the correct ROC.
