### PR TITLE
Set timeout for accept stream not wait indefinitely

### DIFF
--- a/keying_test.go
+++ b/keying_test.go
@@ -11,7 +11,7 @@ type mockKeyingMaterialExporter struct {
 	exported []byte
 }
 
-func (m *mockKeyingMaterialExporter) ExportKeyingMaterial(label string, context []byte, length int) ([]byte, error) {
+func (m *mockKeyingMaterialExporter) ExportKeyingMaterial(label string, _ []byte, length int) ([]byte, error) {
 	if label != labelExtractorDtlsSrtp {
 		return nil, fmt.Errorf("%w: expected(%s) actual(%s)", errExporterWrongLabel, label, labelExtractorDtlsSrtp)
 	}

--- a/session.go
+++ b/session.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/pion/logging"
 	"github.com/pion/transport/v2/packetio"
@@ -21,7 +22,8 @@ type session struct {
 	localContext, remoteContext *Context
 	localOptions, remoteOptions []ContextOption
 
-	newStream chan readStream
+	newStream           chan readStream
+	acceptStreamTimeout time.Time
 
 	started chan interface{}
 	closed  chan interface{}
@@ -41,10 +43,11 @@ type session struct {
 // or directly pass the keys themselves.
 // After a Config is passed to a session it must not be modified.
 type Config struct {
-	Keys          SessionKeys
-	Profile       ProtectionProfile
-	BufferFactory func(packetType packetio.BufferPacketType, ssrc uint32) io.ReadWriteCloser
-	LoggerFactory logging.LoggerFactory
+	Keys                SessionKeys
+	Profile             ProtectionProfile
+	BufferFactory       func(packetType packetio.BufferPacketType, ssrc uint32) io.ReadWriteCloser
+	LoggerFactory       logging.LoggerFactory
+	AcceptStreamTimeout time.Time
 
 	// List of local/remote context options.
 	// ReplayProtection is enabled on remote context by default.
@@ -115,6 +118,10 @@ func (s *session) start(localMasterKey, localMasterSalt, remoteMasterKey, remote
 
 	s.remoteContext, err = CreateContext(remoteMasterKey, remoteMasterSalt, profile, s.remoteOptions...)
 	if err != nil {
+		return err
+	}
+
+	if err = s.nextConn.SetReadDeadline(s.acceptStreamTimeout); err != nil {
 		return err
 	}
 

--- a/session_srtcp.go
+++ b/session_srtcp.go
@@ -46,15 +46,16 @@ func NewSessionSRTCP(conn net.Conn, config *Config) (*SessionSRTCP, error) { //n
 
 	s := &SessionSRTCP{
 		session: session{
-			nextConn:      conn,
-			localOptions:  localOpts,
-			remoteOptions: remoteOpts,
-			readStreams:   map[uint32]readStream{},
-			newStream:     make(chan readStream),
-			started:       make(chan interface{}),
-			closed:        make(chan interface{}),
-			bufferFactory: config.BufferFactory,
-			log:           loggerFactory.NewLogger("srtp"),
+			nextConn:            conn,
+			localOptions:        localOpts,
+			remoteOptions:       remoteOpts,
+			readStreams:         map[uint32]readStream{},
+			newStream:           make(chan readStream),
+			acceptStreamTimeout: config.AcceptStreamTimeout,
+			started:             make(chan interface{}),
+			closed:              make(chan interface{}),
+			bufferFactory:       config.BufferFactory,
+			log:                 loggerFactory.NewLogger("srtp"),
 		},
 	}
 	s.writeStream = &WriteStreamSRTCP{s}
@@ -165,6 +166,9 @@ func (s *SessionSRTCP) decrypt(buf []byte) error {
 		if r == nil {
 			return nil // Session has been closed
 		} else if isNew {
+			if !s.session.acceptStreamTimeout.IsZero() {
+				_ = s.session.nextConn.SetReadDeadline(time.Time{})
+			}
 			s.session.newStream <- r // Notify AcceptStream
 		}
 

--- a/session_srtcp_test.go
+++ b/session_srtcp_test.go
@@ -301,6 +301,42 @@ func TestSessionSRTCPReplayProtection(t *testing.T) {
 	}
 }
 
+// nolint: dupl
+func TestSessionSRTCPAcceptStreamTimeout(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	pipe, _ := net.Pipe()
+	config := &Config{
+		Profile: ProtectionProfileAes128CmHmacSha1_80,
+		Keys: SessionKeys{
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A, 0xAB, 0xE6},
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A, 0xAB, 0xE6},
+		},
+		AcceptStreamTimeout: time.Now().Add(3 * time.Second),
+	}
+
+	newSession, err := NewSessionSRTCP(pipe, config)
+	if err != nil {
+		t.Fatal(err)
+	} else if newSession == nil {
+		t.Fatal("NewSessionSRTCP did not error, but returned nil session")
+	}
+
+	if _, _, err = newSession.AcceptStream(); err == nil || !errors.Is(err, errStreamAlreadyClosed) {
+		t.Fatal(err)
+	}
+
+	if err = newSession.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func getSenderSSRC(t *testing.T, stream *ReadStreamSRTCP) (ssrc uint32, err error) {
 	authTagSize, err := ProtectionProfileAes128CmHmacSha1_80.rtcpAuthTagLen()
 	if err != nil {

--- a/session_srtp.go
+++ b/session_srtp.go
@@ -47,15 +47,16 @@ func NewSessionSRTP(conn net.Conn, config *Config) (*SessionSRTP, error) { //nol
 
 	s := &SessionSRTP{
 		session: session{
-			nextConn:      conn,
-			localOptions:  localOpts,
-			remoteOptions: remoteOpts,
-			readStreams:   map[uint32]readStream{},
-			newStream:     make(chan readStream),
-			started:       make(chan interface{}),
-			closed:        make(chan interface{}),
-			bufferFactory: config.BufferFactory,
-			log:           loggerFactory.NewLogger("srtp"),
+			nextConn:            conn,
+			localOptions:        localOpts,
+			remoteOptions:       remoteOpts,
+			readStreams:         map[uint32]readStream{},
+			newStream:           make(chan readStream),
+			acceptStreamTimeout: config.AcceptStreamTimeout,
+			started:             make(chan interface{}),
+			closed:              make(chan interface{}),
+			bufferFactory:       config.BufferFactory,
+			log:                 loggerFactory.NewLogger("srtp"),
 		},
 	}
 	s.writeStream = &WriteStreamSRTP{s}
@@ -171,6 +172,9 @@ func (s *SessionSRTP) decrypt(buf []byte) error {
 	if r == nil {
 		return nil // Session has been closed
 	} else if isNew {
+		if !s.session.acceptStreamTimeout.IsZero() {
+			_ = s.session.nextConn.SetReadDeadline(time.Time{})
+		}
 		s.session.newStream <- r // Notify AcceptStream
 	}
 

--- a/session_srtp_test.go
+++ b/session_srtp_test.go
@@ -355,6 +355,42 @@ func TestSessionSRTPReplayProtection(t *testing.T) {
 	}
 }
 
+// nolint: dupl
+func TestSessionSRTPAcceptStreamTimeout(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	pipe, _ := net.Pipe()
+	config := &Config{
+		Profile: ProtectionProfileAes128CmHmacSha1_80,
+		Keys: SessionKeys{
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A, 0xAB, 0xE6},
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A, 0xAB, 0xE6},
+		},
+		AcceptStreamTimeout: time.Now().Add(3 * time.Second),
+	}
+
+	newSession, err := NewSessionSRTP(pipe, config)
+	if err != nil {
+		t.Fatal(err)
+	} else if newSession == nil {
+		t.Fatal("NewSessionSRTP did not error, but returned nil session")
+	}
+
+	if _, _, err = newSession.AcceptStream(); err == nil || !errors.Is(err, errStreamAlreadyClosed) {
+		t.Fatal(err)
+	}
+
+	if err = newSession.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func assertPayloadSRTP(t *testing.T, stream *ReadStreamSRTP, headerSize int, expectedPayload []byte) (seq uint16, err error) {
 	readBuffer := make([]byte, headerSize+len(expectedPayload))
 	n, hdr, err := stream.ReadRTP(readBuffer)

--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -14,15 +14,15 @@ import (
 
 type noopConn struct{ closed chan struct{} }
 
-func newNoopConn() *noopConn                           { return &noopConn{closed: make(chan struct{})} }
-func (c *noopConn) Read(b []byte) (n int, err error)   { <-c.closed; return 0, io.EOF }
-func (c *noopConn) Write(b []byte) (n int, err error)  { return len(b), nil }
-func (c *noopConn) Close() error                       { close(c.closed); return nil }
-func (c *noopConn) LocalAddr() net.Addr                { return nil }
-func (c *noopConn) RemoteAddr() net.Addr               { return nil }
-func (c *noopConn) SetDeadline(t time.Time) error      { return nil }
-func (c *noopConn) SetReadDeadline(t time.Time) error  { return nil }
-func (c *noopConn) SetWriteDeadline(t time.Time) error { return nil }
+func newNoopConn() *noopConn                          { return &noopConn{closed: make(chan struct{})} }
+func (c *noopConn) Read([]byte) (n int, err error)    { <-c.closed; return 0, io.EOF }
+func (c *noopConn) Write(b []byte) (n int, err error) { return len(b), nil }
+func (c *noopConn) Close() error                      { close(c.closed); return nil }
+func (c *noopConn) LocalAddr() net.Addr               { return nil }
+func (c *noopConn) RemoteAddr() net.Addr              { return nil }
+func (c *noopConn) SetDeadline(time.Time) error       { return nil }
+func (c *noopConn) SetReadDeadline(time.Time) error   { return nil }
+func (c *noopConn) SetWriteDeadline(time.Time) error  { return nil }
 
 func TestBufferFactory(t *testing.T) {
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
#### Description

Add timeout for `AcceptStream` method in `NewSessionSRTP` and `NewSessionSRTCP` methods.

By setting the `AcceptStreamTimeout` value in the `config` parameter when calling the `NewSessionSRTP` or `NewSessionSRTCP` method, the `nextConn.SetReadDeadline` is set in the `session.start` method to prevent the `AcceptStream` method from waiting indefinitely.

When `AcceptStream` is notified via `newStream`, the `nextConn.SetReadDeadline` is released.

#### Reference issue
Fixes #235 
