### PR TITLE
Export unexported functions

### DIFF
--- a/session_srtp.go
+++ b/session_srtp.go
@@ -76,6 +76,16 @@ func NewSessionSRTP(conn net.Conn, config *Config) (*SessionSRTP, error) { //nol
 	return s, nil
 }
 
+// GetNextConn returns the global next connection for the Session
+func (s *SessionSRTP) GetNextConn() net.Conn {
+       return s.nextConn
+}
+
+// GetLocalContext returns the local context for the Session
+func (s *SessionSRTP) GetLocalContext() *Context {
+       return s.localContext
+}
+
 // OpenWriteStream returns the global write stream for the Session
 func (s *SessionSRTP) OpenWriteStream() (*WriteStreamSRTP, error) {
 	return s.writeStream, nil
@@ -135,6 +145,11 @@ var bufferpool = sync.Pool{ // nolint:gochecknoglobals
 	New: func() interface{} {
 		return make([]byte, 1492)
 	},
+}
+
+// WriteRTP encrypts and write a header and payload to nextConn
+func (s *SessionSRTP) WriteRTP(header *rtp.Header, payload []byte) (int, error) {
+       return s.writeRTP(header, payload)
 }
 
 func (s *SessionSRTP) writeRTP(header *rtp.Header, payload []byte) (int, error) {

--- a/srtcp.go
+++ b/srtcp.go
@@ -62,11 +62,6 @@ func (c *Context) DecryptRTCP(dst, encrypted []byte, header *rtcp.Header) ([]byt
 	return c.decryptRTCP(dst, encrypted)
 }
 
-// EncryptRTCP encrypts a buffer that contains a RTCP packet
-func (c *Context) EncryptRTCP(dst, decrypted []byte) ([]byte, error) {
-       return c.encryptRTCP(dst, decrypted)
-}
-
 func (c *Context) encryptRTCP(dst, decrypted []byte) ([]byte, error) {
 	ssrc := binary.BigEndian.Uint32(decrypted[4:])
 	s := c.getSRTCPSSRCState(ssrc)

--- a/srtcp.go
+++ b/srtcp.go
@@ -62,6 +62,11 @@ func (c *Context) DecryptRTCP(dst, encrypted []byte, header *rtcp.Header) ([]byt
 	return c.decryptRTCP(dst, encrypted)
 }
 
+// EncryptRTCP encrypts a buffer that contains a RTCP packet
+func (c *Context) EncryptRTCP(dst, decrypted []byte) ([]byte, error) {
+       return c.encryptRTCP(dst, decrypted)
+}
+
 func (c *Context) encryptRTCP(dst, decrypted []byte) ([]byte, error) {
 	ssrc := binary.BigEndian.Uint32(decrypted[4:])
 	s := c.getSRTCPSSRCState(ssrc)


### PR DESCRIPTION
#### Description
For performance reasons, some projects need to bypass part of the standard pion path and access the SRTP session directly. This PR exports the required functions.
