### PR TITLE
Support selected RCC Transforms from RFC 4771

### DIFF
--- a/context.go
+++ b/context.go
@@ -43,6 +43,23 @@ type srtcpSSRCState struct {
 	replayDetector replaydetector.ReplayDetector
 }
 
+// RCCMode is the mode of Roll-over Counter Carrying Transform from RFC 4771.
+type RCCMode int
+
+const (
+	// RCCModeNone is the default mode.
+	RCCModeNone RCCMode = iota
+	// RCCMode1 is RCCm1 mode from RFC 4771. In this mode ROC and truncated auth tag is sent every R-th packet,
+	// and no auth tag in other ones. This mode is not supported by pion/srtp.
+	RCCMode1
+	// RCCMode2 is RCCm2 mode from RFC 4771. In this mode ROC and truncated auth tag is sent every R-th packet,
+	// and full auth tag in other ones. This mode is supported for AES-CM and NULL profiles only.
+	RCCMode2
+	// RCCMode3 is RCCm3 mode from RFC 4771. In this mode ROC is sent every R-th packet (without truncated auth tag),
+	// and no auth tag in other ones. This mode is supported for AES-GCM profiles only.
+	RCCMode3
+)
+
 // Context represents a SRTP cryptographic context.
 // Context can only be used for one-way operations.
 // it must either used ONLY for encryption or ONLY for decryption.
@@ -67,6 +84,11 @@ type Context struct {
 
 	encryptSRTP  bool
 	encryptSRTCP bool
+
+	rccMode         RCCMode
+	rocTransmitRate uint16
+
+	authTagRTPLen *int
 }
 
 // CreateContext creates a new SRTP Context.
@@ -99,6 +121,21 @@ func CreateContext(
 	) {
 		if errOpt := o(c); errOpt != nil {
 			return nil, errOpt
+		}
+	}
+
+	if err = c.checkRCCMode(); err != nil {
+		return nil, err
+	}
+
+	if c.authTagRTPLen != nil {
+		var authKeyLen int
+		authKeyLen, err = c.profile.AuthKeyLen()
+		if err != nil {
+			return nil, err
+		}
+		if *c.authTagRTPLen > authKeyLen {
+			return nil, errTooLongSRTPAuthTag
 		}
 	}
 
@@ -154,16 +191,21 @@ func (c *Context) createCipher(mki, masterKey, masterSalt []byte, encryptSRTP, e
 		return nil, fmt.Errorf("%w expected(%d) actual(%d)", errShortSrtpMasterSalt, saltLen, masterSaltLen)
 	}
 
+	profileWithArgs := protectionProfileWithArgs{
+		ProtectionProfile: c.profile,
+		authTagRTPLen:     c.authTagRTPLen,
+	}
+
 	switch c.profile {
 	case ProtectionProfileAeadAes128Gcm, ProtectionProfileAeadAes256Gcm:
-		return newSrtpCipherAeadAesGcm(c.profile, masterKey, masterSalt, mki, encryptSRTP, encryptSRTCP)
+		return newSrtpCipherAeadAesGcm(profileWithArgs, masterKey, masterSalt, mki, encryptSRTP, encryptSRTCP)
 	case ProtectionProfileAes128CmHmacSha1_32,
 		ProtectionProfileAes128CmHmacSha1_80,
 		ProtectionProfileAes256CmHmacSha1_32,
 		ProtectionProfileAes256CmHmacSha1_80:
-		return newSrtpCipherAesCmHmacSha1(c.profile, masterKey, masterSalt, mki, encryptSRTP, encryptSRTCP)
+		return newSrtpCipherAesCmHmacSha1(profileWithArgs, masterKey, masterSalt, mki, encryptSRTP, encryptSRTCP)
 	case ProtectionProfileNullHmacSha1_32, ProtectionProfileNullHmacSha1_80:
-		return newSrtpCipherAesCmHmacSha1(c.profile, masterKey, masterSalt, mki, false, false)
+		return newSrtpCipherAesCmHmacSha1(profileWithArgs, masterKey, masterSalt, mki, false, false)
 	default:
 		return nil, fmt.Errorf("%w: %#v", errNoSuchSRTPProfile, c.profile)
 	}
@@ -197,7 +239,7 @@ func (c *Context) SetSendMKI(mki []byte) error {
 }
 
 // https://tools.ietf.org/html/rfc3550#appendix-A.1
-func (s *srtpSSRCState) nextRolloverCount(sequenceNumber uint16) (roc uint32, diff int32, overflow bool) {
+func (s *srtpSSRCState) nextRolloverCount(sequenceNumber uint16) (roc uint32, diff int64, overflow bool) {
 	seq := int32(sequenceNumber)
 	localRoc := uint32(s.index >> 16)            //nolint:gosec // G115
 	localSeq := int32(s.index & (seqNumMax - 1)) //nolint:gosec // G115
@@ -232,17 +274,20 @@ func (s *srtpSSRCState) nextRolloverCount(sequenceNumber uint16) (roc uint32, di
 		}
 	}
 
-	return guessRoc, difference, (guessRoc == 0 && localRoc == maxROC)
+	return guessRoc, int64(difference), (guessRoc == 0 && localRoc == maxROC)
 }
 
-func (s *srtpSSRCState) updateRolloverCount(sequenceNumber uint16, difference int32) {
-	if !s.rolloverHasProcessed {
+func (s *srtpSSRCState) updateRolloverCount(sequenceNumber uint16, difference int64, hasRemoteRoc bool,
+	remoteRoc uint32,
+) {
+	switch {
+	case hasRemoteRoc:
+		s.index = (uint64(remoteRoc) << 16) | uint64(sequenceNumber)
+		s.rolloverHasProcessed = true
+	case !s.rolloverHasProcessed:
 		s.index |= uint64(sequenceNumber)
 		s.rolloverHasProcessed = true
-
-		return
-	}
-	if difference > 0 {
+	case difference > 0:
 		s.index += uint64(difference)
 	}
 }
@@ -308,4 +353,50 @@ func (c *Context) Index(ssrc uint32) (uint32, bool) {
 func (c *Context) SetIndex(ssrc uint32, index uint32) {
 	s := c.getSRTCPSSRCState(ssrc)
 	s.srtcpIndex = index % (maxSRTCPIndex + 1)
+}
+
+//nolint:cyclop
+func (c *Context) checkRCCMode() error {
+	if c.rccMode == RCCModeNone {
+		return nil
+	}
+
+	if c.rocTransmitRate == 0 {
+		return errZeroRocTransmitRate
+	}
+
+	switch c.profile {
+	case ProtectionProfileAeadAes128Gcm, ProtectionProfileAeadAes256Gcm:
+		// AEAD profiles support RCCMode3 only
+		if c.rccMode != RCCMode3 {
+			return errUnsupportedRccMode
+		}
+
+	case ProtectionProfileAes128CmHmacSha1_32,
+		ProtectionProfileAes256CmHmacSha1_32,
+		ProtectionProfileNullHmacSha1_32:
+		if c.authTagRTPLen == nil {
+			// ROC completely replaces auth tag for _32 profiles. If you really want to use 4-byte
+			// SRTP auth tag with RCC, use SRTPAuthenticationTagLength(4) option.
+			return errTooShortSRTPAuthTag
+		}
+
+		fallthrough // Checks below are common for _32 and _80 profiles.
+
+	case ProtectionProfileAes128CmHmacSha1_80,
+		ProtectionProfileAes256CmHmacSha1_80,
+		ProtectionProfileNullHmacSha1_80:
+		// AES-CM and NULL profiles support RCCMode2 only
+		if c.rccMode != RCCMode2 {
+			return errUnsupportedRccMode
+		}
+		if c.authTagRTPLen != nil && *c.authTagRTPLen < 4 {
+			return errTooShortSRTPAuthTag
+		}
+
+	default:
+		return errUnsupportedRccMode
+	}
+
+	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -31,11 +31,16 @@ var (
 	errMKIAlreadyInUse               = errors.New("MKI already in use")
 	errMKIIsNotEnabled               = errors.New("MKI is not enabled")
 	errInvalidMKILength              = errors.New("invalid MKI length")
+	errTooLongSRTPAuthTag            = errors.New("SRTP auth tag is too long")
+	errTooShortSRTPAuthTag           = errors.New("SRTP auth tag is too short")
 
 	errStreamNotInited     = errors.New("stream has not been inited, unable to close")
 	errStreamAlreadyClosed = errors.New("stream is already closed")
 	errStreamAlreadyInited = errors.New("stream is already inited")
 	errFailedTypeAssertion = errors.New("failed to cast child")
+
+	errZeroRocTransmitRate = errors.New("ROC transmit rate is zero")
+	errUnsupportedRccMode  = errors.New("unsupported RCC mode")
 )
 
 type duplicatedError struct {

--- a/protection_profile_with_args.go
+++ b/protection_profile_with_args.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package srtp
+
+// protectionProfileWithArgs is a wrapper around ProtectionProfile that allows to
+// specify additional arguments for the profile.
+type protectionProfileWithArgs struct {
+	ProtectionProfile
+	authTagRTPLen *int
+}
+
+// AuthTagRTPLen returns length of RTP authentication tag in bytes for AES protection profiles.
+// For AEAD ones it returns zero.
+func (p protectionProfileWithArgs) AuthTagRTPLen() (int, error) {
+	if p.authTagRTPLen != nil {
+		return *p.authTagRTPLen, nil
+	}
+
+	return p.ProtectionProfile.AuthTagRTPLen()
+}

--- a/srtcp.go
+++ b/srtcp.go
@@ -10,6 +10,16 @@ import (
 	"github.com/pion/rtcp"
 )
 
+/*
+Simplified structure of SRTCP Packets:
+- RTCP Header
+- Payload
+- AEAD Auth Tag - used by AEAD profiles only
+- E flag and SRTCP Index
+- MKI (optional)
+- Auth Tag - used by non-AEAD profiles only
+*/
+
 const maxSRTCPIndex = 0x7FFFFFFF
 
 const srtcpHeaderSize = 8
@@ -42,7 +52,7 @@ func (c *Context) decryptRTCP(dst, encrypted []byte) ([]byte, error) {
 	cipher := c.cipher
 	if len(c.mkis) > 0 {
 		// Find cipher for MKI
-		actualMKI := c.cipher.getMKI(encrypted, false)
+		actualMKI := encrypted[len(encrypted)-mkiLen-authTagLen : len(encrypted)-authTagLen]
 		cipher, ok = c.mkis[string(actualMKI)]
 		if !ok {
 			return nil, ErrMKINotFound

--- a/srtp_cipher.go
+++ b/srtp_cipher.go
@@ -16,12 +16,11 @@ type srtpCipher interface {
 	// See the note below.
 	AEADAuthTagLen() (int, error)
 	getRTCPIndex([]byte) uint32
-	getMKI([]byte, bool) []byte
 
-	encryptRTP([]byte, *rtp.Header, []byte, uint32) ([]byte, error)
+	encryptRTP([]byte, *rtp.Header, []byte, uint32, bool) ([]byte, error)
 	encryptRTCP([]byte, []byte, uint32, uint32) ([]byte, error)
 
-	decryptRTP([]byte, []byte, *rtp.Header, int, uint32) ([]byte, error)
+	decryptRTP([]byte, []byte, *rtp.Header, int, uint32, bool) ([]byte, error)
 	decryptRTCP([]byte, []byte, uint32, uint32) ([]byte, error)
 }
 

--- a/srtp_cipher_rcc_test.go
+++ b/srtp_cipher_rcc_test.go
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package srtp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests for Roll-over Counter Carrying Transform from RFC 4771
+
+// nolint:cyclop,maintidx
+func TestRCC(t *testing.T) {
+	const (
+		ROC             = uint32(0x12345678)
+		SSRC            = uint32(0xcafebabe)
+		ROCTransmitRate = uint16(10)
+	)
+
+	MKI := []byte{0x05, 0x06, 0x07, 0x08}
+
+	decryptedRTPPacket := []byte{
+		0x80, 0x0f, 0x00, 0x00, 0xde, 0xca, 0xfb, 0xad,
+		0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
+		0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+		0xab, 0xab, 0xab, 0xab,
+	}
+
+	// Test all combinations of profiles, MKI enabled/disabled and RTP encryption enabled/disabled
+	profiles := []ProtectionProfile{
+		ProtectionProfileAes128CmHmacSha1_80,
+		ProtectionProfileAes128CmHmacSha1_32,
+		ProtectionProfileAes256CmHmacSha1_80,
+		ProtectionProfileAes256CmHmacSha1_32,
+		ProtectionProfileAeadAes128Gcm,
+		ProtectionProfileAeadAes256Gcm,
+	}
+	useMkiInTest := map[string]bool{
+		"NoMKI": false,
+		"MKI":   true,
+	}
+	useRTPEncryption := map[string]bool{
+		"Encrypt": false,
+		"NULL":    true,
+	}
+	useLongerAuthTag := map[string]bool{
+		"NormalAuthTag": false,
+		"LongerAuthTag": true,
+	}
+	for _, profile := range profiles {
+		for useMkiName, useMki := range useMkiInTest {
+			for rtpEncryptName, rtpEncrypt := range useRTPEncryption {
+				for longerAuthTagName, longerAuthTag := range useLongerAuthTag {
+					aeadAuthTagLen, err := profile.AEADAuthTagLen()
+					assert.NoError(t, err)
+					if aeadAuthTagLen != 0 && longerAuthTag {
+						continue
+					}
+
+					t.Run(fmt.Sprintf("%s-%s-%s-%s", profile.String(), useMkiName, rtpEncryptName, longerAuthTagName),
+						func(t *testing.T) {
+							keyLen, err := profile.KeyLen()
+							assert.NoError(t, err)
+							saltLen, err := profile.SaltLen()
+							assert.NoError(t, err)
+							authTagLen, err := profile.AuthTagRTPLen()
+							assert.NoError(t, err)
+
+							masterKey := make([]byte, keyLen)
+							masterSalt := make([]byte, saltLen)
+
+							var optsRCC, optsNoRCC []ContextOption
+							if aeadAuthTagLen == 0 {
+								optsRCC = []ContextOption{RolloverCounterCarryingTransform(RCCMode2, ROCTransmitRate)}
+							} else {
+								optsRCC = []ContextOption{RolloverCounterCarryingTransform(RCCMode3, ROCTransmitRate)}
+							}
+
+							appendCtxOpt := func(opt ContextOption) {
+								optsRCC = append(optsRCC, opt)
+								optsNoRCC = append(optsNoRCC, opt)
+							}
+
+							if useMki {
+								appendCtxOpt(MasterKeyIndicator(MKI))
+							}
+							if !rtpEncrypt {
+								appendCtxOpt(SRTPNoEncryption())
+							}
+							if longerAuthTag {
+								appendCtxOpt(SRTPAuthenticationTagLength(authTagLen + 4))
+							} else if authTagLen == 4 {
+								// ROC overrides whole auth tag, need to explicitly set it to 4
+								appendCtxOpt(SRTPAuthenticationTagLength(4))
+							}
+
+							t.Run("CheckEncryptDecryptRTPPacketsWithROC", func(t *testing.T) {
+								ctxEnc, err := CreateContext(masterKey, masterSalt, profile, optsRCC...)
+								assert.NoError(t, err)
+								ctxEnc.SetROC(SSRC, ROC)
+
+								ctxEncNoRCC, err := CreateContext(masterKey, masterSalt, profile, optsNoRCC...)
+								assert.NoError(t, err)
+								ctxEncNoRCC.SetROC(SSRC, ROC)
+
+								ctxDec, err := CreateContext(masterKey, masterSalt, profile, optsRCC...)
+								assert.NoError(t, err)
+
+								rtpPacket := slices.Clone(decryptedRTPPacket)
+								var header rtp.Header
+								_, err = header.Unmarshal(rtpPacket)
+								assert.NoError(t, err)
+								header.SequenceNumber = 0
+								_, err = header.MarshalTo(rtpPacket)
+								assert.NoError(t, err)
+
+								srtpPacketWithROC, err := ctxEnc.EncryptRTP(nil, rtpPacket, nil)
+								assert.NoError(t, err)
+
+								srtpPacketWithoutROC, err := ctxEncNoRCC.EncryptRTP(nil, rtpPacket, nil)
+								assert.NoError(t, err)
+
+								pktLen := len(srtpPacketWithROC)
+								switch {
+								case aeadAuthTagLen == 0 && !longerAuthTag:
+									// AES-CM with default auth tag length - ROC is at the beginning of the auth tag,
+									// which is shifted and truncated by 4 bytes
+									assert.Equal(t, pktLen, len(srtpPacketWithoutROC))
+									// ROC
+									assert.Equal(t, ROC, binary.BigEndian.Uint32(srtpPacketWithROC[pktLen-authTagLen:]))
+									// Header, payload, MKI
+									assert.Equal(t, srtpPacketWithROC[:pktLen-authTagLen],
+										srtpPacketWithoutROC[:pktLen-authTagLen])
+									// Auth tag
+									assert.Equal(t, srtpPacketWithROC[pktLen-authTagLen+4:],
+										srtpPacketWithoutROC[pktLen-authTagLen:pktLen-4])
+								case aeadAuthTagLen == 0 && longerAuthTag:
+									// AES-CM with auth tag length increased by 4 - ROC is at the beginning of the auth tag
+									assert.Equal(t, pktLen, len(srtpPacketWithoutROC))
+									// ROC
+									assert.Equal(t, ROC, binary.BigEndian.Uint32(srtpPacketWithROC[pktLen-authTagLen-4:]))
+									// Header, payload, MKI
+									assert.Equal(t, srtpPacketWithROC[:pktLen-authTagLen-4],
+										srtpPacketWithoutROC[:pktLen-authTagLen-4])
+									// Auth tag
+									assert.Equal(t, srtpPacketWithROC[pktLen-authTagLen:],
+										srtpPacketWithoutROC[pktLen-authTagLen-4:pktLen-4])
+								default:
+									// AEAD - ROC is appended at the end of the packet
+									assert.Equal(t, pktLen-4, len(srtpPacketWithoutROC))
+									// ROC
+									assert.Equal(t, ROC, binary.BigEndian.Uint32(srtpPacketWithROC[pktLen-4:]))
+									// Header, payload, AEAD auth tag, MKI
+									assert.Equal(t, srtpPacketWithROC[:pktLen-4], srtpPacketWithoutROC)
+								}
+
+								decrypted, err := ctxDec.DecryptRTP(nil, srtpPacketWithROC, nil)
+								assert.NoError(t, err)
+								assert.Equal(t, rtpPacket, decrypted)
+							})
+
+							t.Run("CheckEncryptDecryptRTPPacketsWithoutROC", func(t *testing.T) {
+								ctxEnc, err := CreateContext(masterKey, masterSalt, profile, optsRCC...)
+								assert.NoError(t, err)
+								ctxEnc.SetROC(SSRC, ROC)
+
+								ctxEncNoRCC, err := CreateContext(masterKey, masterSalt, profile, optsNoRCC...)
+								assert.NoError(t, err)
+								ctxEncNoRCC.SetROC(SSRC, ROC)
+
+								ctxDec, err := CreateContext(masterKey, masterSalt, profile, optsRCC...)
+								assert.NoError(t, err)
+								ctxDec.SetROC(SSRC, ROC)
+
+								rtpPacket := slices.Clone(decryptedRTPPacket)
+								var header rtp.Header
+								_, err = header.Unmarshal(rtpPacket)
+								assert.NoError(t, err)
+								header.SequenceNumber = 1
+								_, err = header.MarshalTo(rtpPacket)
+								assert.NoError(t, err)
+
+								srtpPacket1, err := ctxEnc.EncryptRTP(nil, rtpPacket, nil)
+								assert.NoError(t, err)
+
+								srtpPacket2, err := ctxEncNoRCC.EncryptRTP(nil, rtpPacket, nil)
+								assert.NoError(t, err)
+
+								assert.Equal(t, srtpPacket1, srtpPacket2)
+
+								decrypted, err := ctxDec.DecryptRTP(nil, srtpPacket1, nil)
+								assert.NoError(t, err)
+								assert.Equal(t, rtpPacket, decrypted)
+							})
+
+							t.Run("CheckROCFromSRTPPacketIsUsed", func(t *testing.T) {
+								ctxEnc, err := CreateContext(masterKey, masterSalt, profile, optsRCC...)
+								assert.NoError(t, err)
+								ctxEnc.SetROC(SSRC, ROC)
+
+								ctxDec, err := CreateContext(masterKey, masterSalt, profile, optsRCC...)
+								assert.NoError(t, err)
+								// Do not set ROC in ctxDec
+
+								rtpPacket := slices.Clone(decryptedRTPPacket)
+								var header rtp.Header
+								_, err = header.Unmarshal(rtpPacket)
+								assert.NoError(t, err)
+
+								for n := ROCTransmitRate - 1; n <= ROCTransmitRate+1; n++ {
+									header.SequenceNumber = n
+									_, err = header.MarshalTo(rtpPacket)
+									assert.NoError(t, err)
+
+									srtpPacket, err := ctxEnc.EncryptRTP(nil, rtpPacket, nil)
+									assert.NoError(t, err)
+
+									_, err = ctxDec.DecryptRTP(nil, srtpPacket, nil)
+									if n == ROCTransmitRate-1 {
+										assert.ErrorIs(t, err, ErrFailedToVerifyAuthTag)
+									} else {
+										assert.NoError(t, err)
+									}
+								}
+							})
+
+							t.Run("CheckROCTransmitRate", func(t *testing.T) {
+								ctxEnc, err := CreateContext(masterKey, masterSalt, profile, optsRCC...)
+								assert.NoError(t, err)
+								ctxEnc.SetROC(SSRC, ROC)
+
+								ctxEncNoRCC, err := CreateContext(masterKey, masterSalt, profile, optsNoRCC...)
+								assert.NoError(t, err)
+								ctxEncNoRCC.SetROC(SSRC, ROC)
+
+								rtpPacket := slices.Clone(decryptedRTPPacket)
+								var header rtp.Header
+								_, err = header.Unmarshal(rtpPacket)
+								assert.NoError(t, err)
+
+								for n := uint16(0); n <= ROCTransmitRate*4; n++ {
+									header.SequenceNumber = n
+									_, err = header.MarshalTo(rtpPacket)
+									assert.NoError(t, err)
+
+									srtpPacket1, err := ctxEnc.EncryptRTP(nil, rtpPacket, nil)
+									assert.NoError(t, err)
+
+									srtpPacket2, err := ctxEncNoRCC.EncryptRTP(nil, rtpPacket, nil)
+									assert.NoError(t, err)
+
+									if n%ROCTransmitRate == 0 {
+										assert.NotEqual(t, srtpPacket1, srtpPacket2)
+									} else {
+										assert.Equal(t, srtpPacket1, srtpPacket2)
+									}
+								}
+							})
+						})
+				}
+			}
+		}
+	}
+}

--- a/srtp_cipher_utils_test.go
+++ b/srtp_cipher_utils_test.go
@@ -33,9 +33,9 @@ func newSrtpCipherAesCmHmacSha1WithDerivedKeys(
 	}
 
 	srtpCipher := &srtpCipherAesCmHmacSha1{
-		ProtectionProfile: profile,
-		srtpEncrypted:     encryptSRTP,
-		srtcpEncrypted:    encryptSRTCP,
+		protectionProfileWithArgs: protectionProfileWithArgs{ProtectionProfile: profile},
+		srtpEncrypted:             encryptSRTP,
+		srtcpEncrypted:            encryptSRTCP,
 	}
 
 	var err error
@@ -62,9 +62,9 @@ func newSrtpCipherAeadAesGcmWithDerivedKeys(
 	encryptSRTP, encryptSRTCP bool,
 ) (*srtpCipherAeadAesGcm, error) {
 	srtpCipher := &srtpCipherAeadAesGcm{
-		ProtectionProfile: profile,
-		srtpEncrypted:     encryptSRTP,
-		srtcpEncrypted:    encryptSRTCP,
+		protectionProfileWithArgs: protectionProfileWithArgs{ProtectionProfile: profile},
+		srtpEncrypted:             encryptSRTP,
+		srtcpEncrypted:            encryptSRTCP,
 	}
 
 	srtpBlock, err := aes.NewCipher(keys.srtpSessionKey)

--- a/srtp_test.go
+++ b/srtp_test.go
@@ -85,7 +85,7 @@ func TestRolloverCount(t *testing.T) { //nolint:cyclop
 	assert.Empty(t, roc, "Initial rollover counter must be 0")
 	assert.False(t, ovf, "Should not overflow")
 
-	ssrcState.updateRolloverCount(65530, diff)
+	ssrcState.updateRolloverCount(65530, diff, false, 0)
 
 	// Invalid packets never update ROC
 	ssrcState.nextRolloverCount(0)
@@ -99,45 +99,45 @@ func TestRolloverCount(t *testing.T) { //nolint:cyclop
 	assert.Equal(t, uint32(1), roc, "rolloverCounter must be incremented after wrapping")
 	assert.False(t, ovf, "Should not overflow")
 
-	ssrcState.updateRolloverCount(0, diff)
+	ssrcState.updateRolloverCount(0, diff, false, 0)
 
 	roc, diff, ovf = ssrcState.nextRolloverCount(65530)
 	assert.Empty(t, roc, "rolloverCounter was not updated when it rolled back, failed to handle out of order")
 	assert.False(t, ovf, "Should not overflow")
 
-	ssrcState.updateRolloverCount(65530, diff)
+	ssrcState.updateRolloverCount(65530, diff, false, 0)
 
 	roc, diff, ovf = ssrcState.nextRolloverCount(5)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was not updated when it rolled over initial, to handle out of order")
 	assert.False(t, ovf, "Should not overflow")
 
-	ssrcState.updateRolloverCount(5, diff)
+	ssrcState.updateRolloverCount(5, diff, false, 0)
 
 	_, diff, _ = ssrcState.nextRolloverCount(6)
-	ssrcState.updateRolloverCount(6, diff)
+	ssrcState.updateRolloverCount(6, diff, false, 0)
 	_, diff, _ = ssrcState.nextRolloverCount(7)
-	ssrcState.updateRolloverCount(7, diff)
+	ssrcState.updateRolloverCount(7, diff, false, 0)
 	roc, diff, _ = ssrcState.nextRolloverCount(8)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was improperly updated for non-significant packets")
 
-	ssrcState.updateRolloverCount(8, diff)
+	ssrcState.updateRolloverCount(8, diff, false, 0)
 
 	// valid packets never update ROC
 	roc, diff, ovf = ssrcState.nextRolloverCount(0x4000)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	ssrcState.updateRolloverCount(0x4000, diff)
+	ssrcState.updateRolloverCount(0x4000, diff, false, 0)
 	roc, diff, ovf = ssrcState.nextRolloverCount(0x8000)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	ssrcState.updateRolloverCount(0x8000, diff)
+	ssrcState.updateRolloverCount(0x8000, diff, false, 0)
 	roc, diff, ovf = ssrcState.nextRolloverCount(0xFFFF)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	ssrcState.updateRolloverCount(0xFFFF, diff)
+	ssrcState.updateRolloverCount(0xFFFF, diff, false, 0)
 	roc, _, ovf = ssrcState.nextRolloverCount(0)
 	assert.Equal(t, uint32(2), roc, "rolloverCounter must be incremented after wrapping")
 	assert.False(t, ovf, "Should not overflow")
@@ -148,7 +148,7 @@ func TestRolloverCountOverflow(t *testing.T) {
 		ssrc:  defaultSsrc,
 		index: maxROC << 16,
 	}
-	s.updateRolloverCount(0xFFFF, 0)
+	s.updateRolloverCount(0xFFFF, 0, false, 0)
 	_, _, ovf := s.nextRolloverCount(0)
 	assert.True(t, ovf, "Should overflow")
 }
@@ -573,54 +573,54 @@ func TestRolloverCount2(t *testing.T) { //nolint:cyclop
 	assert.Equal(t, uint32(0), roc, "Initial rolloverCounter must be 0")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(30123, diff)
+	srtpState.updateRolloverCount(30123, diff, false, 0)
 
 	roc, diff, ovf = srtpState.nextRolloverCount(62892) // 30123 + (1 << 15) + 1
 	assert.Equal(t, uint32(0), roc, "Initial rolloverCounter must be 0")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(62892, diff)
+	srtpState.updateRolloverCount(62892, diff, false, 0)
 	roc, diff, ovf = srtpState.nextRolloverCount(204)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was not updated after it crossed 0")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(62892, diff)
+	srtpState.updateRolloverCount(62892, diff, false, 0)
 	roc, diff, ovf = srtpState.nextRolloverCount(64535)
 	assert.Equal(t, uint32(0), roc, "rolloverCounter was not updated when it rolled back, failed to handle out of order")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(64535, diff)
+	srtpState.updateRolloverCount(64535, diff, false, 0)
 	roc, diff, ovf = srtpState.nextRolloverCount(205)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(205, diff)
+	srtpState.updateRolloverCount(205, diff, false, 0)
 	roc, diff, ovf = srtpState.nextRolloverCount(1)
 	assert.Equal(t, uint32(1), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(1, diff)
+	srtpState.updateRolloverCount(1, diff, false, 0)
 
 	roc, diff, ovf = srtpState.nextRolloverCount(64532)
 	assert.Equal(t, uint32(0), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(64532, diff)
+	srtpState.updateRolloverCount(64532, diff, false, 0)
 	roc, diff, ovf = srtpState.nextRolloverCount(65534)
 	assert.Equal(t, uint32(0), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(65534, diff)
+	srtpState.updateRolloverCount(65534, diff, false, 0)
 	roc, diff, ovf = srtpState.nextRolloverCount(64532)
 	assert.Equal(t, uint32(0), roc, "rolloverCounter was improperly updated for non-significant packets")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(65532, diff)
+	srtpState.updateRolloverCount(65532, diff, false, 0)
 	roc, diff, ovf = srtpState.nextRolloverCount(205)
 	assert.Equal(t, uint32(1), roc, "index was not updated after it crossed 0")
 	assert.False(t, ovf, "Should not overflow")
 
-	srtpState.updateRolloverCount(65532, diff)
+	srtpState.updateRolloverCount(65532, diff, false, 0)
 }
 
 func TestProtectionProfileAes128CmHmacSha1_32(t *testing.T) {


### PR DESCRIPTION
Roll-over Counter Carrying Transform specified in RFC 4771 defines way to send Roll-over Counter in Authentication Tag of SRTP packet. This allows late joiners to reliably discover current value of ROC.

RFC 4771 defines 3 RCC modes. This PR adds support for mode RCCm2 for AES-CM and NULL profiles, and mode RCCm3 for AES-GCM (AEAD) profiles.

Modes RCCm1 and RCCm3 disables authentication tag so they decrease security of AES-CM profiles. For AES-GCM profiles modes RCCm1 and RCCm2 would require to calculate SHA-1 MAC in addition to existing AEAD tag, unnecessary causing extra CPU load and increasing SRTP packet size.
