### PR TITLE
Properly encrypt RTP packets with padding

### DIFF
--- a/srtp.go
+++ b/srtp.go
@@ -113,13 +113,14 @@ func (c *Context) EncryptRTP(dst []byte, plaintext []byte, header *rtp.Header) (
 		return nil, err
 	}
 
-	return c.encryptRTP(dst, header, plaintext[headerLen:])
+	return c.encryptRTP(dst, header, headerLen, plaintext)
 }
 
 // encryptRTP marshals and encrypts an RTP packet, writing to the dst buffer provided.
 // If the dst buffer does not have the capacity, a new one will be allocated and returned.
 // Similar to above but faster because it can avoid unmarshaling the header and marshaling the payload.
-func (c *Context) encryptRTP(dst []byte, header *rtp.Header, payload []byte) (ciphertext []byte, err error) {
+func (c *Context) encryptRTP(dst []byte, header *rtp.Header, headerLen int, plaintext []byte,
+) (ciphertext []byte, err error) {
 	s := c.getSRTPSSRCState(header.SSRC)
 	roc, diff, ovf := s.nextRolloverCount(header.SequenceNumber)
 	if ovf {
@@ -136,7 +137,7 @@ func (c *Context) encryptRTP(dst []byte, header *rtp.Header, payload []byte) (ci
 		rocInPacket = true
 	}
 
-	return c.cipher.encryptRTP(dst, header, payload, roc, rocInPacket)
+	return c.cipher.encryptRTP(dst, header, headerLen, plaintext, roc, rocInPacket)
 }
 
 func (c *Context) hasROCInPacket(header *rtp.Header, authTagLen int) (bool, int) {

--- a/srtp_cipher.go
+++ b/srtp_cipher.go
@@ -17,7 +17,7 @@ type srtpCipher interface {
 	AEADAuthTagLen() (int, error)
 	getRTCPIndex([]byte) uint32
 
-	encryptRTP([]byte, *rtp.Header, []byte, uint32, bool) ([]byte, error)
+	encryptRTP([]byte, *rtp.Header, int, []byte, uint32, bool) ([]byte, error)
 	encryptRTCP([]byte, []byte, uint32, uint32) ([]byte, error)
 
 	decryptRTP([]byte, []byte, *rtp.Header, int, uint32, bool) ([]byte, error)

--- a/srtp_cipher_test.go
+++ b/srtp_cipher_test.go
@@ -591,6 +591,18 @@ func TestSrtpCipher(t *testing.T) {
 					assert.NoError(t, err)
 					assert.Equal(t, testCase.encryptedRTPPacket, actualEncrypted)
 				})
+
+				t.Run("Same buffer", func(t *testing.T) {
+					buffer := make([]byte, 0, 1000)
+					src, dst := buffer, buffer
+					src = append(src, testCase.decryptedRTPPacket...)
+					assert.True(t, isSameBuffer(dst, src))
+
+					actualEncrypted, err := ctx.EncryptRTP(dst, src, nil)
+					assert.NoError(t, err)
+					assert.Equal(t, testCase.encryptedRTPPacket, actualEncrypted)
+					assert.True(t, isSameBuffer(actualEncrypted, src))
+				})
 			})
 
 			t.Run("Decrypt RTP", func(t *testing.T) {


### PR DESCRIPTION
This is another part of fix for https://github.com/pion/webrtc/issues/2403 . One more PR is still needed for `pion/webrtc` to fix this bug for apps who still use `PaddingSize` field in `rtp.Packet` instead of new one in `rtp.Header`.