### PR TITLE
Fixes to use the same buffer as input and output

### DIFF
--- a/context.go
+++ b/context.go
@@ -24,8 +24,6 @@ const (
 
 	seqNumMedian = 1 << 15
 	seqNumMax    = 1 << 16
-
-	srtcpIndexSize = 4
 )
 
 // Encrypt/Decrypt state for a single SRTP SSRC.

--- a/srtcp.go
+++ b/srtcp.go
@@ -20,9 +20,13 @@ Simplified structure of SRTCP Packets:
 - Auth Tag - used by non-AEAD profiles only
 */
 
-const maxSRTCPIndex = 0x7FFFFFFF
+const (
+	maxSRTCPIndex = 0x7FFFFFFF
 
-const srtcpHeaderSize = 8
+	srtcpHeaderSize     = 8
+	srtcpIndexSize      = 4
+	srtcpEncryptionFlag = 0x80
+)
 
 func (c *Context) decryptRTCP(dst, encrypted []byte) ([]byte, error) {
 	authTagLen, err := c.cipher.AuthTagRTCPLen()
@@ -59,9 +63,7 @@ func (c *Context) decryptRTCP(dst, encrypted []byte) ([]byte, error) {
 		}
 	}
 
-	out := allocateIfMismatch(dst, encrypted)
-
-	out, err = cipher.decryptRTCP(out, encrypted, index, ssrc)
+	out, err := cipher.decryptRTCP(dst, encrypted, index, ssrc)
 	if err != nil {
 		return nil, err
 	}

--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@
 package srtp
 
 import (
-	"bytes"
 	"unsafe"
 )
 
@@ -18,25 +17,6 @@ func growBufferSize(buf []byte, size int) []byte {
 	copy(buf2, buf)
 
 	return buf2
-}
-
-// allocateIfMismatch checks if buffers match, if not allocates a new buffer and returns it.
-func allocateIfMismatch(dst, src []byte) []byte {
-	if dst == nil {
-		dst = make([]byte, len(src))
-		copy(dst, src)
-	} else if !bytes.Equal(dst, src) { // bytes.Equal returns on ref equality, no optimization needed
-		extraNeeded := len(src) - len(dst)
-		if extraNeeded > 0 {
-			dst = append(dst, make([]byte, extraNeeded)...) //nolint:makezero // todo: fix
-		} else if extraNeeded < 0 {
-			dst = dst[:len(dst)+extraNeeded]
-		}
-
-		copy(dst, src)
-	}
-
-	return dst
 }
 
 // isSameBuffer returns true if slices a and b share the same underlying buffer.


### PR DESCRIPTION
Added checks for the same buffer to stop copying data when not needed. Also fixed srtpCipherAesCmHmacSha1 to work with one buffer when encrypting and decrypting RTCP packets.
