### PR TITLE
We never allocate more than 32 bytes AES/CTR

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -20,16 +20,18 @@ func incrementCTR(ctr []byte) {
 	}
 }
 
+const xorBufferSize = 32
+
 var xorBufferPool = sync.Pool{ // nolint:gochecknoglobals
 	New: func() any {
-		return make([]byte, 1500)
+		return make([]byte, xorBufferSize)
 	},
 }
 
 // xorBytesCTR performs CTR encryption and decryption.
 // It is equivalent to cipher.NewCTR followed by XORKeyStream.
 func xorBytesCTR(block cipher.Block, iv []byte, dst, src []byte) error {
-	if len(iv) != block.BlockSize() {
+	if len(iv) != block.BlockSize() || (len(iv)+block.BlockSize()) > xorBufferSize {
 		return errBadIVLength
 	}
 

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -18,6 +18,40 @@ func xorBytesCTRReference(block cipher.Block, iv []byte, dst, src []byte) {
 	stream.XORKeyStream(dst, src)
 }
 
+func benchmarkAESCTR(block cipher.Block, iv []byte, dst, src []byte) {
+	_ = xorBytesCTR(block, iv, dst, src)
+}
+
+func BenchmarkAES128CTRAlloc(b *testing.B) {
+	b.ReportAllocs()
+	const keysize = 16
+	key := make([]byte, keysize)
+	_, _ = rand.Read(key) //nolint: gosec,staticcheck
+	block, _ := aes.NewCipher(key)
+	iv := make([]byte, block.BlockSize())
+	src := make([]byte, 0)
+	dst := make([]byte, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkAESCTR(block, iv, dst, src)
+	}
+}
+
+func BenchmarkAES256CTRAlloc(b *testing.B) {
+	b.ReportAllocs()
+	const keysize = 32
+	key := make([]byte, keysize)
+	_, _ = rand.Read(key) //nolint: gosec,staticcheck
+	block, _ := aes.NewCipher(key)
+	iv := make([]byte, block.BlockSize())
+	src := make([]byte, 0)
+	dst := make([]byte, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkAESCTR(block, iv, dst, src)
+	}
+}
+
 func TestXorBytesCTR(t *testing.T) {
 	for keysize := 16; keysize < 64; keysize *= 2 {
 		key := make([]byte, keysize)


### PR DESCRIPTION
#### we never allocate more than 32 bytes, add benchmark for allocation

#### Reference issue
Fixes #322 
