### PR TITLE
Do not recalculate RTP header size

### DIFF
--- a/srtp_cipher_aead_aes_gcm.go
+++ b/srtp_cipher_aead_aes_gcm.go
@@ -101,7 +101,7 @@ func (s *srtpCipherAeadAesGcm) encryptRTP(
 		return nil, err
 	}
 	payloadLen := len(plaintext) - headerLen
-	authPartLen := header.MarshalSize() + payloadLen + authTagLen
+	authPartLen := headerLen + payloadLen + authTagLen
 	dstLen := authPartLen + len(s.mki)
 	if rocInAuthTag {
 		dstLen += 4


### PR DESCRIPTION
Use header size passed via parameter instead of calculating it again.