### PR TITLE
ECN support

### DIFF
--- a/session.go
+++ b/session.go
@@ -146,7 +146,7 @@ func (s *session) start(
 		}()
 
 		b := make([]byte, 8192)
-		attr := transport.NewPacketAttributes()
+		attr := transport.NewPacketAttributesWithLen(transport.MaxAttributesLen)
 		for {
 			n, err := s.nextConn.ReadWithAttributes(b, attr)
 			if err != nil {
@@ -157,7 +157,7 @@ func (s *session) start(
 				return
 			}
 
-			if err = child.decryptWithAttributes(b[:n], attr); err != nil {
+			if err = child.decryptWithAttributes(b[:n], attr.GetReadPacketAttributes()); err != nil {
 				s.log.Info(err.Error())
 			}
 		}

--- a/stream.go
+++ b/stream.go
@@ -3,9 +3,14 @@
 
 package srtp
 
+import "github.com/pion/transport/v3"
+
 type readStream interface {
 	init(child streamSession, ssrc uint32) error
 
 	Read(buf []byte) (int, error)
+
+	ReadWithAttributes(b []byte, attr *transport.PacketAttributes) (int, error)
+
 	GetSSRC() uint32
 }

--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -39,7 +39,7 @@ func TestBufferFactory(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	conn := newNoopConn()
-	bf := func(_ packetio.BufferPacketType, _ uint32) io.ReadWriteCloser {
+	bf := func(_ packetio.BufferPacketType, _ uint32) *packetio.Buffer {
 		wg.Done()
 
 		return packetio.NewBuffer()


### PR DESCRIPTION
The `ReadStreamSRTP`, `ReadStreamSRTCP`, `SessionSRTP`, and `SessionSRTCP` have been changed with additional `ReadWithAttributes` methods and other needed methods. The important point is, `nextConn` 's type is now `transport.NetConnSocket`, which is a wrapper around `net.Conn`, where the new ReadWithAttributes method just behaves like Read. In the case where ECN is needed, `NewSessionSRTPWithNewSocket` should be used.