### PR TITLE
Split RTCP compound packet before forwarding

### DIFF
--- a/session_srtcp.go
+++ b/session_srtcp.go
@@ -4,6 +4,7 @@
 package srtp
 
 import (
+	"errors"
 	"net"
 	"time"
 
@@ -141,12 +142,11 @@ func (s *SessionSRTCP) setWriteDeadline(t time.Time) error {
 	return s.session.nextConn.SetWriteDeadline(t)
 }
 
-// create a list of Destination SSRCs
-// that's a superset of all Destinations in the slice.
-func destinationSSRC(pkts []rtcp.Packet) []uint32 {
+// create a list of Destination SSRCs that's a superset of all Destinations in the given packets.
+func destinationSSRC(pkts ...rtcp.Packet) []uint32 {
 	ssrcSet := make(map[uint32]struct{})
-	for _, p := range pkts {
-		for _, ssrc := range p.DestinationSSRC() {
+	for _, pkt := range pkts {
+		for _, ssrc := range pkt.DestinationSSRC() {
 			ssrcSet[ssrc] = struct{}{}
 		}
 	}
@@ -159,38 +159,63 @@ func destinationSSRC(pkts []rtcp.Packet) []uint32 {
 	return out
 }
 
+//nolint:cyclop
 func (s *SessionSRTCP) decrypt(buf []byte) error {
 	decrypted, err := s.remoteContext.DecryptRTCP(buf, buf, nil)
 	if err != nil {
 		return err
 	}
 
-	pkt, err := rtcp.Unmarshal(decrypted)
+	pkts, err := rtcp.Unmarshal(decrypted)
 	if err != nil {
 		return err
 	}
 
-	for _, ssrc := range destinationSSRC(pkt) {
-		r, isNew := s.session.getOrCreateReadStream(ssrc, s, newReadStreamSRTCP)
-		if r == nil {
-			return nil // Session has been closed
-		} else if isNew {
-			if !s.session.acceptStreamTimeout.IsZero() {
-				_ = s.session.nextConn.SetReadDeadline(time.Time{})
-			}
-			s.session.newStream <- r // Notify AcceptStream
-		}
-
-		readStream, ok := r.(*ReadStreamSRTCP)
-		if !ok {
-			return errFailedTypeAssertion
-		}
-
-		_, err = readStream.write(decrypted)
+	var compoundSSRCs []uint32
+	var marshalErrs error
+	for _, pkt := range pkts {
+		marshaled, err := pkt.Marshal()
 		if err != nil {
-			return err
+			// Skip the packet that failed to remarshal so the remaining
+			// packets in the compound are still forwarded.
+			marshalErrs = errors.Join(marshalErrs, err)
+
+			continue
+		}
+
+		destinations := destinationSSRC(pkt)
+		if len(destinations) == 0 {
+			// Packets without a destination of their own (e.g. unknown packet
+			// types parsed as rtcp.RawPacket) are delivered to every stream the
+			// compound packet is addressed to instead of being dropped.
+			if compoundSSRCs == nil {
+				compoundSSRCs = destinationSSRC(pkts...)
+			}
+			destinations = compoundSSRCs
+		}
+
+		for _, ssrc := range destinations {
+			r, isNew := s.session.getOrCreateReadStream(ssrc, s, newReadStreamSRTCP)
+			if r == nil {
+				return nil // Session has been closed
+			} else if isNew {
+				if !s.session.acceptStreamTimeout.IsZero() {
+					_ = s.session.nextConn.SetReadDeadline(time.Time{})
+				}
+				s.session.newStream <- r // Notify AcceptStream
+			}
+
+			readStream, ok := r.(*ReadStreamSRTCP)
+			if !ok {
+				return errFailedTypeAssertion
+			}
+
+			_, err = readStream.write(marshaled)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	return nil
+	return marshalErrs
 }

--- a/session_srtcp_test.go
+++ b/session_srtcp_test.go
@@ -245,6 +245,377 @@ func TestSessionSRTCPReplayProtection(t *testing.T) {
 		expectedSSRC, receivedSSRC)
 }
 
+func TestSessionSRTCPCompoundPacket(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	testSSRCSenderReport1SR := uint32(0x902f9e2e)
+	testSSRCSenderReport1RR := uint32(0xbc5e9a40)
+	testSSRCCNAME := uint32(1234)
+	testSSRCSenderReport2SR := uint32(0x12345678)
+	aSession, bSession := buildSessionSRTCPPair(t)
+	bReadStreamSR1SR, err := bSession.OpenReadStream(testSSRCSenderReport1SR)
+	assert.NoError(t, err)
+	bReadStreamSR1RR, err := bSession.OpenReadStream(testSSRCSenderReport1RR)
+	assert.NoError(t, err)
+	bReadStreamCNAME, err := bSession.OpenReadStream(testSSRCCNAME)
+	assert.NoError(t, err)
+	bReadStreamSR2SR, err := bSession.OpenReadStream(testSSRCSenderReport2SR)
+	assert.NoError(t, err)
+
+	// Compound packet
+	// first packet - Sender Report with a Receiver Report
+	// second packet - Sender Report without a Receiver Report
+	cp := &rtcp.CompoundPacket{
+		&rtcp.SenderReport{
+			SSRC:        testSSRCSenderReport1SR,
+			NTPTime:     0xda8bd1fcdddda05a,
+			RTPTime:     0xaaf4edd5,
+			PacketCount: 1,
+			OctetCount:  2,
+			Reports: []rtcp.ReceptionReport{{
+				SSRC:               testSSRCSenderReport1RR,
+				FractionLost:       0,
+				TotalLost:          0,
+				LastSequenceNumber: 0x46e1,
+				Jitter:             273,
+				LastSenderReport:   0x9f36432,
+				Delay:              150137,
+			}},
+			ProfileExtensions: []byte{
+				0x81, 0xca, 0x0, 0x6,
+				0x2b, 0x7e, 0xc0, 0xc5,
+				0x1, 0x10, 0x4c, 0x63,
+				0x49, 0x66, 0x7a, 0x58,
+				0x6f, 0x6e, 0x44, 0x6f,
+				0x72, 0x64, 0x53, 0x65,
+				0x57, 0x36, 0x0, 0x0,
+			},
+		},
+		rtcp.NewCNAMESourceDescription(testSSRCCNAME, "cname"), // to make it a valid compound packet
+		&rtcp.SenderReport{
+			SSRC:        testSSRCSenderReport2SR,
+			NTPTime:     0xda8bd1fcdddda05a,
+			RTPTime:     0xaaf4edd5,
+			PacketCount: 1,
+			OctetCount:  2,
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		readBuffer := make([]byte, 200)
+
+		senderReport := &rtcp.SenderReport{}
+		n, _, rerr := bReadStreamSR1SR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		rerr = senderReport.Unmarshal(readBuffer[:n])
+		assert.NoError(t, rerr)
+		assert.Equal(t, uint32(0x902f9e2e), senderReport.SSRC)
+		assert.Len(t, senderReport.Reports, 1)
+		assert.Equal(t, uint32(0xbc5e9a40), senderReport.Reports[0].SSRC)
+		assert.Len(t, senderReport.DestinationSSRC(), 2)
+		assert.ElementsMatch(t, []uint32{0x902f9e2e, 0xbc5e9a40}, senderReport.DestinationSSRC())
+
+		// should read via receiver report embedded in sender report
+		senderReport = &rtcp.SenderReport{}
+		n, _, rerr = bReadStreamSR1RR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		rerr = senderReport.Unmarshal(readBuffer[:n])
+		assert.NoError(t, rerr)
+		assert.Equal(t, uint32(0x902f9e2e), senderReport.SSRC)
+		assert.Len(t, senderReport.Reports, 1)
+		assert.Equal(t, uint32(0xbc5e9a40), senderReport.Reports[0].SSRC)
+		assert.Len(t, senderReport.DestinationSSRC(), 2)
+		assert.ElementsMatch(t, []uint32{0x902f9e2e, 0xbc5e9a40}, senderReport.DestinationSSRC())
+
+		cname := &rtcp.SourceDescription{}
+		n, _, rerr = bReadStreamCNAME.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		rerr = cname.Unmarshal(readBuffer[:n])
+		assert.NoError(t, rerr)
+		assert.Len(t, cname.DestinationSSRC(), 1)
+		assert.Equal(t, uint32(1234), cname.DestinationSSRC()[0])
+
+		senderReport = &rtcp.SenderReport{}
+		n, _, rerr = bReadStreamSR2SR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		rerr = senderReport.Unmarshal(readBuffer[:n])
+		assert.NoError(t, rerr)
+		assert.Equal(t, uint32(0x12345678), senderReport.SSRC)
+		assert.Len(t, senderReport.Reports, 0)
+		assert.Len(t, senderReport.DestinationSSRC(), 1)
+		assert.ElementsMatch(t, []uint32{0x12345678}, senderReport.DestinationSSRC())
+
+		close(done)
+	}()
+
+	encrypted, err := encryptSRTCP(aSession.session.localContext, cp)
+	assert.NoError(t, err)
+	_, err = aSession.session.nextConn.Write(encrypted)
+	assert.NoError(t, err)
+
+	<-done
+
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+	assert.NoError(t, bReadStreamSR1SR.Close())
+	assert.NoError(t, bReadStreamSR1RR.Close())
+	assert.NoError(t, bReadStreamCNAME.Close())
+	assert.NoError(t, bReadStreamSR2SR.Close())
+}
+
+func TestSessionSRTCPCompoundPacketWithEmptyDestinationSSRC(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	testSSRCSenderReportSR := uint32(0x902f9e2e)
+	testSSRCSenderReportRR := uint32(0xbc5e9a40)
+	// Unknown packet type (221), parsed as rtcp.RawPacket whose
+	// DestinationSSRC() is empty. It should still be delivered to every
+	// stream the compound packet is addressed to.
+	rawPacket := rtcp.RawPacket([]byte{
+		0x80, 0xdd, 0x00, 0x01,
+		0x01, 0x02, 0x03, 0x04,
+	})
+
+	aSession, bSession := buildSessionSRTCPPair(t)
+	bReadStreamSR, err := bSession.OpenReadStream(testSSRCSenderReportSR)
+	assert.NoError(t, err)
+	bReadStreamRR, err := bSession.OpenReadStream(testSSRCSenderReportRR)
+	assert.NoError(t, err)
+
+	cp := &rtcp.CompoundPacket{
+		&rtcp.SenderReport{
+			SSRC: testSSRCSenderReportSR,
+			Reports: []rtcp.ReceptionReport{{
+				SSRC: testSSRCSenderReportRR,
+			}},
+		},
+		rtcp.NewCNAMESourceDescription(testSSRCSenderReportSR, "cname"),
+		&rawPacket,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		readBuffer := make([]byte, 200)
+
+		// stream for the sender SSRC: SenderReport, SourceDescription, RawPacket
+		_, header, rerr := bReadStreamSR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		assert.Equal(t, rtcp.TypeSenderReport, header.Type)
+
+		_, header, rerr = bReadStreamSR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		assert.Equal(t, rtcp.TypeSourceDescription, header.Type)
+
+		n, header, rerr := bReadStreamSR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		assert.Equal(t, rtcp.PacketType(221), header.Type)
+		assert.Equal(t, []byte(rawPacket), readBuffer[:n])
+
+		// stream for the reception report SSRC: SenderReport, RawPacket
+		_, header, rerr = bReadStreamRR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		assert.Equal(t, rtcp.TypeSenderReport, header.Type)
+
+		n, header, rerr = bReadStreamRR.ReadRTCP(readBuffer)
+		assert.NoError(t, rerr)
+		assert.Equal(t, rtcp.PacketType(221), header.Type)
+		assert.Equal(t, []byte(rawPacket), readBuffer[:n])
+
+		close(done)
+	}()
+
+	encrypted, err := encryptSRTCP(aSession.session.localContext, cp)
+	assert.NoError(t, err)
+	_, err = aSession.session.nextConn.Write(encrypted)
+	assert.NoError(t, err)
+
+	<-done
+
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+	assert.NoError(t, bReadStreamSR.Close())
+	assert.NoError(t, bReadStreamRR.Close())
+}
+
+func TestSessionSRTCPDecryptInvalidRTCP(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	aSession, bSession := buildSessionSRTCPPair(t)
+
+	// Valid RTCP header that claims a larger length than the payload carries.
+	invalidRTCP := []byte{0x81, 0xc8, 0x00, 0x0c, 0x90, 0x2f, 0x9e, 0x2e}
+	encrypted, err := aSession.session.localContext.EncryptRTCP(nil, invalidRTCP, nil)
+	assert.NoError(t, err)
+	assert.Error(t, bSession.decrypt(encrypted))
+
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+}
+
+func TestSessionSRTCPDecryptRemarshalFailure(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	aSession, bSession := buildSessionSRTCPPair(t)
+
+	bReadStream, err := bSession.OpenReadStream(5000)
+	assert.NoError(t, err)
+
+	// Application defined packet whose data is too large to remarshal
+	// (rtcp.ApplicationDefined.Marshal allows less data than a maximum
+	// length header can describe).
+	oversizedAppPacket := make([]byte, 65540)
+	oversizedAppPacket[0] = 0x80 // version 2
+	oversizedAppPacket[1] = 0xcc // packet type 204 (application defined)
+	oversizedAppPacket[2] = 0x40 // length 0x4000, i.e. (0x4000+1)*4 == 65540 bytes
+	oversizedAppPacket[3] = 0x00
+	copy(oversizedAppPacket[8:12], "name")
+
+	// A packet that fails to remarshal is skipped, the remaining packets in
+	// the compound are still forwarded.
+	pli, err := (&rtcp.PictureLossIndication{MediaSSRC: 5000}).Marshal()
+	assert.NoError(t, err)
+	compound := make([]byte, 0, len(oversizedAppPacket)+len(pli))
+	compound = append(compound, oversizedAppPacket...)
+	compound = append(compound, pli...)
+
+	encrypted, err := aSession.session.localContext.EncryptRTCP(nil, compound, nil)
+	assert.NoError(t, err)
+	assert.Error(t, bSession.decrypt(encrypted))
+
+	readBuffer := make([]byte, len(pli))
+	n, _, err := bReadStream.ReadRTCP(readBuffer)
+	assert.NoError(t, err)
+	assert.Equal(t, pli, readBuffer[:n])
+
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+	assert.NoError(t, bReadStream.Close())
+}
+
+func TestSessionSRTCPDecryptClosedSession(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	aSession, bSession := buildSessionSRTCPPair(t)
+	assert.NoError(t, bSession.Close())
+
+	encrypted, err := encryptSRTCP(aSession.session.localContext, &rtcp.PictureLossIndication{MediaSSRC: 5000})
+	assert.NoError(t, err)
+	// The session is closed, decrypt drops the packet without an error.
+	assert.NoError(t, bSession.decrypt(encrypted))
+
+	assert.NoError(t, aSession.Close())
+}
+
+func TestSessionSRTCPDecryptWrongStreamType(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	aSession, bSession := buildSessionSRTCPPair(t)
+
+	bSession.session.readStreamsLock.Lock()
+	bSession.session.readStreams[5000] = &ReadStreamSRTP{}
+	bSession.session.readStreamsLock.Unlock()
+
+	encrypted, err := encryptSRTCP(aSession.session.localContext, &rtcp.PictureLossIndication{MediaSSRC: 5000})
+	assert.NoError(t, err)
+	assert.ErrorIs(t, bSession.decrypt(encrypted), errFailedTypeAssertion)
+
+	bSession.session.readStreamsLock.Lock()
+	delete(bSession.session.readStreams, 5000)
+	bSession.session.readStreamsLock.Unlock()
+
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+}
+
+func TestSessionSRTCPDecryptClosedReadStream(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	aSession, bSession := buildSessionSRTCPPair(t)
+
+	bReadStream, err := bSession.OpenReadStream(5000)
+	assert.NoError(t, err)
+	// Close the underlying buffer while keeping the stream registered
+	// in the session so the stream write fails.
+	assert.NoError(t, bReadStream.buffer.Close())
+
+	encrypted, err := encryptSRTCP(aSession.session.localContext, &rtcp.PictureLossIndication{MediaSSRC: 5000})
+	assert.NoError(t, err)
+	assert.Error(t, bSession.decrypt(encrypted))
+
+	assert.NoError(t, bReadStream.Close())
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+}
+
+func TestSessionSRTCPAcceptStreamClearsTimeout(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	aPipe, bPipe := net.Pipe()
+	config := &Config{
+		Profile: ProtectionProfileAes128CmHmacSha1_80,
+		Keys: SessionKeys{
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A, 0xAB, 0xE6},
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A, 0xAB, 0xE6},
+		},
+		AcceptStreamTimeout: time.Now().Add(3 * time.Second),
+	}
+
+	aSession, err := NewSessionSRTCP(aPipe, config)
+	assert.NoError(t, err)
+	bSession, err := NewSessionSRTCP(bPipe, config)
+	assert.NoError(t, err)
+
+	testPayload, err := rtcp.Marshal([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: 5000}})
+	assert.NoError(t, err)
+	aWriteStream, err := aSession.OpenWriteStream()
+	assert.NoError(t, err)
+	_, err = aWriteStream.Write(testPayload)
+	assert.NoError(t, err)
+
+	bReadStream, ssrc, err := bSession.AcceptStream()
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(5000), ssrc)
+
+	assert.NoError(t, bReadStream.Close())
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+}
+
 // nolint: dupl
 func TestSessionSRTCPAcceptStreamTimeout(t *testing.T) {
 	lim := test.TimeOut(time.Second * 5)


### PR DESCRIPTION
    Split RTCP compound packet before forwarding
    
    When a compound RTCP packet is received, it is forwarded as is to the
    read streams. Downstream components have to check for the SSRC in the
    packets matching the track(s) it is handling.
    
    This leads to situations where downstream components could see duplicate
    RTCP reports. Happens when there is a downstream handler for all SSRCs.
    It receives the compound packet, unmarshals it and invokes the handlers.
    As it is fielding all SSRCs, it will get the same compound packet `n`
    times and invoke the handlers `n` times.
    
    This PR splits up the compound packet and forwards individual packets to
    avoid the end handlers from seeing duplicates. API wise, it is
    compatible as it still emits an encoded/marshaled packet. But, this does
    add a marshaling step.
    
    Packets that have no destination SSRC of their own (e.g. unknown packet
    types parsed as rtcp.RawPacket, or receiver reports with no reception
    reports) are delivered to every stream the compound packet is addressed
    to, instead of being dropped. Such packets can still be seen once per
    compound packet by each of those streams, matching the old behavior.
    
    Add unit tests. Before this change, the compound packet test fails at
    the point where the test tries to read the CNAME packet and sees an
    incorrect type, and the empty destination SSRC test blocks forever
    waiting for the rtcp.RawPacket to be forwarded.