### PR TITLE
Reuse rtp.Header in SessionSRTP.decrypt

### DIFF
--- a/session_srtp.go
+++ b/session_srtp.go
@@ -21,6 +21,10 @@ const defaultSessionSRTPReplayProtectionWindow = 64
 type SessionSRTP struct {
 	session
 	writeStream *WriteStreamSRTP
+
+	// readHeader is reused by decrypt across packets to avoid a per-packet
+	// allocation and must only be used on the session read loop.
+	readHeader rtp.Header
 }
 
 // NewSessionSRTP creates a SRTP session using conn as the underlying transport.
@@ -183,9 +187,19 @@ func (s *SessionSRTP) setWriteDeadline(t time.Time) error {
 }
 
 func (s *SessionSRTP) decrypt(buf []byte) error {
-	header := &rtp.Header{}
+	header := &s.readHeader
+
+	// Save the CSRC and extension slices in case the packet fails to decrypt
+	// or authenticate; if the packet doesn't authenticate, then restore the
+	// old slices to prevent an attacker from growing the memory footprint.
+	oldCSRC := header.CSRC
+	oldExtensions := header.Extensions
+
 	headerLen, err := header.Unmarshal(buf)
 	if err != nil {
+		header.CSRC = oldCSRC
+		header.Extensions = oldExtensions
+
 		return err
 	}
 
@@ -196,6 +210,9 @@ func (s *SessionSRTP) decrypt(buf []byte) error {
 	// unauthenticated peer to exhaust memory by spoofing arbitrary SSRCs.
 	decrypted, err := s.remoteContext.decryptRTP(buf, buf, header, headerLen)
 	if err != nil {
+		header.CSRC = oldCSRC
+		header.Extensions = oldExtensions
+
 		return err
 	}
 

--- a/session_srtp_test.go
+++ b/session_srtp_test.go
@@ -4,6 +4,7 @@
 package srtp
 
 import (
+	"encoding/binary"
 	"errors"
 	"io"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/logging"
 	"github.com/pion/rtp"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
@@ -466,4 +468,295 @@ func TestSessionSRTPPacketWithPadding(t *testing.T) {
 
 	assert.NoError(t, aSession.Close())
 	assert.NoError(t, bSession.Close())
+}
+
+func TestSessionSRTPRejectedPacketDoesNotGrowRetainedHeader(t *testing.T) {
+	const (
+		packetSize             = 8192
+		rtpFixedHeaderSize     = 12
+		rtpExtensionHeaderSize = 4
+		initialCapacity        = 1
+	)
+
+	assertDoesNotGrow := func(t *testing.T, receiver *SessionSRTP, packet []byte) {
+		t.Helper()
+
+		receiver.readHeader.CSRC = make([]uint32, 0, initialCapacity)
+		receiver.readHeader.Extensions = make([]rtp.Extension, 0, initialCapacity)
+
+		assert.Error(t, receiver.decrypt(packet))
+		assert.Equal(t, initialCapacity, cap(receiver.readHeader.CSRC))
+		assert.Equal(t, initialCapacity, cap(receiver.readHeader.Extensions))
+	}
+
+	t.Run("invalid CSRC header", func(t *testing.T) {
+		// CC=15 causes Header.Unmarshal to grow the CSRC slice before
+		// discovering that the packet is too short.
+		packet := make([]byte, rtpFixedHeaderSize)
+		packet[0] = 2<<6 | 15
+
+		assertDoesNotGrow(t, &SessionSRTP{}, packet)
+	})
+
+	t.Run("invalid extension header", func(t *testing.T) {
+		packet := make([]byte, packetSize)
+		packet[0] = 2<<6 | 1<<4 // Version 2, extension bit set.
+
+		extensionOffset := rtpFixedHeaderSize
+		binary.BigEndian.PutUint16(
+			packet[extensionOffset:],
+			rtp.ExtensionProfileTwoByte,
+		)
+
+		extensionData := packet[extensionOffset+rtpExtensionHeaderSize:]
+		binary.BigEndian.PutUint16(
+			packet[extensionOffset+2:],
+			uint16(len(extensionData)/4), //nolint:gosec
+		)
+
+		// Add thousands of valid zero-length extensions, followed by one byte
+		// of padding and an extension ID without its required length byte.
+		// Unmarshal therefore grows Extensions substantially before failing.
+		for i := 0; i < len(extensionData)-2; i += 2 {
+			extensionData[i] = 1
+		}
+		extensionData[len(extensionData)-1] = 1
+
+		assertDoesNotGrow(t, &SessionSRTP{}, packet)
+	})
+
+	t.Run("authentication failure", func(t *testing.T) {
+		const (
+			authTagSize = 16
+			csrcCount   = 15
+			testSSRC    = 5000
+		)
+
+		key := make([]byte, 16)
+		salt := make([]byte, 12)
+
+		encryptContext, err := CreateContext(
+			key,
+			salt,
+			ProtectionProfileAeadAes128Gcm,
+		)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		decryptContext, err := CreateContext(
+			key,
+			salt,
+			ProtectionProfileAeadAes128Gcm,
+		)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		plaintext := make([]byte, packetSize-authTagSize)
+		plaintext[0] = 2<<6 | 1<<4 | csrcCount
+		binary.BigEndian.PutUint32(plaintext[8:], testSSRC)
+
+		extensionOffset := rtpFixedHeaderSize + (csrcCount * 4)
+		binary.BigEndian.PutUint16(
+			plaintext[extensionOffset:],
+			rtp.ExtensionProfileTwoByte,
+		)
+
+		extensionData := plaintext[extensionOffset+rtpExtensionHeaderSize:]
+		binary.BigEndian.PutUint16(
+			plaintext[extensionOffset+2:],
+			uint16(len(extensionData)/4), //nolint:gosec
+		)
+
+		// Each two-byte extension consists of an ID and a zero payload length.
+		for i := 0; i < len(extensionData); i += 2 {
+			extensionData[i] = 1
+		}
+
+		encrypted, err := encryptContext.EncryptRTP(nil, plaintext, nil)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		// Ensure authentication fails after the header slices have been grown.
+		encrypted[len(encrypted)-1] ^= 0xFF
+
+		receiver := &SessionSRTP{
+			session: session{remoteContext: decryptContext},
+		}
+		assertDoesNotGrow(t, receiver, encrypted)
+	})
+}
+
+func TestSessionSRTPReadWriteDoesNotAllocate(t *testing.T) {
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	const testSSRC = 5000
+	testPayload := []byte{0x00, 0x01, 0x03, 0x04}
+	readBuffer := make([]byte, 1500)
+
+	// Note: this does not use buildSessionSRTPPair for two reasons:
+	// - The CTR cipher uses a sync.Pool, which under the race detector
+	//   always allocates.
+	// - The default replay detector (as of pion/transport 4.0.2) allocates
+	//
+	// In order to isolate allocations to this package and avoid race
+	// detector related allocations, test the GCM cipher using a no-op
+	// replay detector instead.
+	aPipe, bPipe := net.Pipe()
+	noReplayProtection := []ContextOption{
+		SRTPNoReplayProtection(),
+		SRTCPNoReplayProtection(),
+	}
+	config := &Config{
+		Profile: ProtectionProfileAeadAes128Gcm,
+		Keys: SessionKeys{
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A},
+			[]byte{0xE1, 0xF9, 0x7A, 0x0D, 0x3E, 0x01, 0x8B, 0xE0, 0xD6, 0x4F, 0xA3, 0x2C, 0x06, 0xDE, 0x41, 0x39},
+			[]byte{0x0E, 0xC6, 0x75, 0xAD, 0x49, 0x8A, 0xFE, 0xEB, 0xB6, 0x96, 0x0B, 0x3A},
+		},
+		LocalOptions:  noReplayProtection,
+		RemoteOptions: noReplayProtection,
+	}
+
+	aSession, err := NewSessionSRTP(aPipe, config)
+	assert.NoError(t, err)
+	assert.NotNil(t, aSession, "NewSessionSRTP did not error, but returned nil session")
+
+	bSession, err := NewSessionSRTP(bPipe, config)
+	assert.NoError(t, err)
+	assert.NotNil(t, bSession, "NewSessionSRTP did not error, but returned nil session")
+
+	bReadStream, err := bSession.OpenReadStream(testSSRC)
+	assert.NoError(t, err)
+	aWriteStream, err := aSession.OpenWriteStream()
+	assert.NoError(t, err)
+
+	header := &rtp.Header{
+		Version:          2,
+		SSRC:             testSSRC,
+		Extension:        true,
+		ExtensionProfile: rtp.ExtensionProfileOneByte,
+	}
+	assert.NoError(t, header.SetExtension(1, []byte{0xAA, 0xBB}))
+
+	roundTrip := func() (int, error) {
+		header.SequenceNumber++
+		if _, err := aWriteStream.WriteRTP(header, testPayload); err != nil {
+			return 0, err
+		}
+
+		return bReadStream.Read(readBuffer)
+	}
+
+	for range 100 {
+		_, err := roundTrip()
+		assert.NoError(t, err)
+	}
+
+	var roundTripErr error
+	allocs := testing.AllocsPerRun(1000, func() {
+		if _, err := roundTrip(); err != nil {
+			roundTripErr = err
+		}
+	})
+
+	assert.NoError(t, roundTripErr)
+	assert.Zero(t, allocs)
+
+	assert.NoError(t, aSession.Close())
+	assert.NoError(t, bSession.Close())
+}
+
+func BenchmarkSessionSRTPReadWrite(b *testing.B) {
+	for _, profile := range []ProtectionProfile{
+		ProtectionProfileAes128CmHmacSha1_80,
+		ProtectionProfileAes128CmHmacSha1_32,
+		ProtectionProfileAes256CmHmacSha1_80,
+		ProtectionProfileAes256CmHmacSha1_32,
+		ProtectionProfileNullHmacSha1_80,
+		ProtectionProfileNullHmacSha1_32,
+		ProtectionProfileAeadAes128Gcm,
+		ProtectionProfileAeadAes256Gcm,
+	} {
+		b.Run(profile.String(), func(b *testing.B) {
+			keyLen, err := profile.KeyLen()
+			assert.NoError(b, err)
+			saltLen, err := profile.SaltLen()
+			assert.NoError(b, err)
+			key := make([]byte, keyLen)
+			salt := make([]byte, saltLen)
+			for i := range key {
+				key[i] = byte(i + 1)
+			}
+			for i := range salt {
+				salt[i] = byte(i + 101)
+			}
+
+			// See TestSessionSRTPReadWriteDoesNotAllocate for why this
+			// doesn't use buildSessionSRTPPair.
+			aPipe, bPipe := net.Pipe()
+			noReplayProtection := []ContextOption{
+				SRTPNoReplayProtection(),
+				SRTCPNoReplayProtection(),
+			}
+			loggerFactory := logging.NewDefaultLoggerFactory()
+			loggerFactory.DefaultLogLevel.Set(logging.LogLevelDisabled)
+			config := &Config{
+				LoggerFactory: loggerFactory,
+				Profile:       profile,
+				Keys: SessionKeys{
+					LocalMasterKey:   key,
+					LocalMasterSalt:  salt,
+					RemoteMasterKey:  key,
+					RemoteMasterSalt: salt,
+				},
+				LocalOptions:  noReplayProtection,
+				RemoteOptions: noReplayProtection,
+			}
+
+			aSession, err := NewSessionSRTP(aPipe, config)
+			assert.NoError(b, err)
+			bSession, err := NewSessionSRTP(bPipe, config)
+			assert.NoError(b, err)
+			defer func() {
+				assert.NoError(b, aSession.Close())
+				assert.NoError(b, bSession.Close())
+			}()
+
+			bReadStream, err := bSession.OpenReadStream(5000)
+			assert.NoError(b, err)
+			aWriteStream, err := aSession.OpenWriteStream()
+			assert.NoError(b, err)
+
+			header := &rtp.Header{
+				Version:          2,
+				SSRC:             5000,
+				Extension:        true,
+				ExtensionProfile: rtp.ExtensionProfileOneByte,
+			}
+			assert.NoError(b, header.SetExtension(1, []byte{0xAA, 0xBB}))
+			testPayload := []byte{0x00, 0x01, 0x03, 0x04}
+			readBuffer := make([]byte, 1500)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				header.SequenceNumber++
+				if _, err := aWriteStream.WriteRTP(header, testPayload); err != nil {
+					b.Fatal(err)
+				}
+				if _, err := bReadStream.Read(readBuffer); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Decrypt used to allocate a new header for every inbound RTP packet, causing 1 or more allocations (extensions could cause several allocations due to slice growth, and CSRC could add one more). Reusing a header, something `(*Context).decryptRTP()` already supports, avoids that allocation.

`rtp.Header` supports reuse and will reuse the extension and CSRC slices when possible, causing per-packet allocations to drop to zero inside the srtp package.

Safety note: the header does not currently escape the srtp package to callers. The public `(*Context).DecryptRTP()` API seems to encourage (or at least allow) header reuse, so this change does not seem to add any new obligations. In fact, if somehow the header was retained or leaked to the caller, this would be a bug as the extension payloads alias the payload buffer that is already reused today.

Future work: srtp does still incur an allocation per incoming packet due to the replay detector. Removing this would likely involve a breaking API change in the replay detector.

Benchmark on all ciphers show a reduction from 2 allocs/op to 0 allocs/op (test packet had a single extension).